### PR TITLE
Add try catch block to avoid IE to break.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -433,7 +433,11 @@ exports.default = _react2.default.createClass({
       focused: false
     });
     if (this.props.onBlur) {
-      this.props.onBlur(new Event("Change Date"));
+      try{
+        this.props.onBlur(new Event("Change Date"));
+      }catch(e){
+        // Object doesn't support action
+      }
     }
     if (this.props.onChange) {
       this.props.onChange(newSelectedDate.toISOString());


### PR DESCRIPTION
Hi Guys,
I create this change in order to be able to set by props the onBlur event and it doesn't break the JS in IE11 since the call constructor of new Event() is not supported.

