### PR TITLE
Don't fire onBlur with synthetic event in handlChange

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -397,11 +397,6 @@ exports.default = _react2.default.createClass({
       value: newSelectedDate.toISOString(),
       focused: false
     });
-    if (this.props.onBlur) {
-      var event = document.createEvent('CustomEvent');
-      event.initEvent("Change Date", true, false);
-      this.props.onBlur(event);
-    }
     if (this.props.onChange) {
       this.props.onChange(newSelectedDate.toISOString());
     }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -347,11 +347,6 @@ export default React.createClass({
       value: newSelectedDate.toISOString(),
       focused: false
     });
-    if(this.props.onBlur) {
-      const event = document.createEvent('CustomEvent');
-      event.initEvent("Change Date", true, false);
-      this.props.onBlur(event);
-    }
     if(this.props.onChange) {
       this.props.onChange(newSelectedDate.toISOString());
     }


### PR DESCRIPTION
A lot of libraries (most notably, redux-form) expect the blur event to
have an event.target.value defined, like it would for the blur event of
a native input element.

I could have munged the synthetic event to mock up these values, but I
didn't quite see the need; it's not clear to me that a value change
semantically justifies a call to onBlur. If someone has a use case where
this *is* required, I'm open to changing this.