### PR TITLE
Added calendarContainer property

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,11 @@ DatePicker component. Renders as a [React-Bootstrap InputGroup](https://react-bo
     * **Optional**
     * **Type:** `string`
     * **Example:** `"top"`
-  * `weekStartsOnMonday` - Makes the calendar's weel to start on Monday.
+  * `calendarContainer` - Overlay container for the popover calendar. When placing the date-picker in a scrolling container, set this prop to some ancestor of the scrolling container.
+    * **Optional**
+    * **Type:** A DOM element or a component
+    * **Example:** `document.body`
+  * `weekStartsOnMonday` - Makes the calendar's week to start on Monday.
     * **Optional**
     * **Type:** `boolean`
     * **Example:** `true`

--- a/example/app.jsx
+++ b/example/app.jsx
@@ -14,6 +14,8 @@ import HelpBlock from 'react-bootstrap/lib/HelpBlock';
 
 const spanishDayLabels = ['Dom', 'Lu', 'Ma', 'Mx', 'Ju', 'Vi', 'Sab'];
 const spanishMonthLabels = ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre'];
+const wapperDivStyle = { border: '1px solid #ccc' };
+const scrollingDivStyle = { padding: '10px', height: '70px', overflow: 'auto' };
 
 const App = React.createClass({
   getInitialState() {
@@ -207,6 +209,31 @@ const App = React.createClass({
             <DatePicker placeholder="Placeholder" calendarPlacement="left" />
             <HelpBlock>Help</HelpBlock>
           </FormGroup>
+        </Col>
+      </Row>
+      <Row>
+        <Col xs={12}>
+          <h2>Placed in a Scrolling Container</h2>
+        </Col>
+      </Row>
+      <Row>
+        <Col sm={6}>
+          <h4>Popover in scroll region</h4>
+          <div style={wapperDivStyle}>
+            <div style={scrollingDivStyle}>
+                <DatePicker placeholder="Start Date" /><br/>
+                <DatePicker placeholder="End Date" />
+            </div>
+          </div>
+        </Col>
+        <Col sm={6}>
+          <h4>Popover outside scroll region</h4>
+          <div style={wapperDivStyle}>
+            <div style={scrollingDivStyle}>
+                <DatePicker placeholder="Start Date" calendarContainer={document.body} /><br/>
+                <DatePicker placeholder="End Date"  calendarContainer={document.body} />
+            </div>
+          </div>
         </Col>
       </Row>
       <Row>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -384,7 +384,7 @@ export default React.createClass({
       monthLabels={this.props.monthLabels}
       dateFormat={this.props.dateFormat} />;
     return <InputGroup ref="inputGroup" bsClass={this.props.bsClass} bsSize={this.props.bsSize} id={this.props.id ? this.props.id + "_group" : null}>
-      <Overlay rootClose={true} onHide={this.handleHide} show={this.state.focused} container={() => ReactDOM.findDOMNode(this.refs.overlayContainer)} target={() => ReactDOM.findDOMNode(this.refs.input)} placement={this.props.calendarPlacement} delayHide={200}>
+      <Overlay rootClose={true} onHide={this.handleHide} show={this.state.focused} container={() => this.props.calendarContainer || ReactDOM.findDOMNode(this.refs.overlayContainer)} target={() => ReactDOM.findDOMNode(this.refs.input)} placement={this.props.calendarPlacement} delayHide={200}>
         <Popover id="calendar" title={calendarHeader}>
           <Calendar cellPadding={this.props.cellPadding} selectedDate={this.state.selectedDate} displayDate={this.state.displayDate} onChange={this.onChangeDate} dayLabels={this.state.dayLabels} weekStartsOnMonday={this.props.weekStartsOnMonday} />
         </Popover>

--- a/test/core.test.jsx
+++ b/test/core.test.jsx
@@ -14,14 +14,18 @@ const spanishMonthLabels = ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio
 
 describe("Date Picker", function() {
   this.timeout(30000);
-  let container;
+  let container, calendarContainer;
   before(function(){
     container = document.createElement("div");
     container.id = "react";
     document.getElementsByTagName('body')[0].appendChild(container);
+    calendarContainer = document.createElement("div"); // optional container for the calendar popover
+    calendarContainer.id = "calendarContainer";
+    document.getElementsByTagName('body')[0].appendChild(calendarContainer);
   });
   after(function(){
     document.getElementsByTagName('body')[0].removeChild(container);
+    document.getElementsByTagName('body')[0].removeChild(calendarContainer);
   });
   it("should render an empty date picker.", co.wrap(function *(){
     const id = UUID.v4();
@@ -404,6 +408,23 @@ describe("Date Picker", function() {
     const inputElement = document.querySelector("input.form-control");
     TestUtils.Simulate.focus(inputElement);
     assert.equal(document.querySelector("table thead tr:first-child td small").innerHTML, "Mon");
+    ReactDOM.unmountComponentAtNode(container);
+  }));
+  it("should allow placing the popover calendar in a container specified in the props.", co.wrap(function *(){
+    const id = UUID.v4();
+    const App = React.createClass({
+      render: function(){
+        return <div>
+          <DatePicker id={id} calendarContainer={calendarContainer} />
+        </div>;
+      }
+    });
+    yield new Promise(function(resolve, reject){
+      ReactDOM.render(<App />, container, resolve);
+    });
+    const inputElement = document.querySelector("input.form-control");
+    TestUtils.Simulate.focus(inputElement);
+    assert.notEqual(document.querySelector("#calendarContainer #calendar"), null);
     ReactDOM.unmountComponentAtNode(container);
   }));
 });


### PR DESCRIPTION
This property allows the popover calendar to work correctly when the date-picker is placed inside a scrolling container. Fixes #33.