### PR TITLE
Modified so the disabled property ensures there is no pop-up or that …

### DIFF
--- a/example/app.jsx
+++ b/example/app.jsx
@@ -289,6 +289,18 @@ const App = React.createClass({
           </FormGroup>
         </Col>
       </Row>
+      <Row>
+        <Col xs={12}>
+          <h2>Disabled</h2>
+        </Col>
+      </Row>
+      <Row>
+        <Col sm={6}>
+          <FormGroup controlId="disabled">
+            <DatePicker disabled placeholder="Placeholder" value={this.state.date} id="disabled_example" />
+          </FormGroup>
+        </Col>
+      </Row>
     </Grid>;
   }
 });

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -136,6 +136,7 @@ export default React.createClass({
       React.PropTypes.string,
       React.PropTypes.object
     ]),
+    disabled: React.PropTypes.bool,
     calendarPlacement: React.PropTypes.string,
     dateFormat: React.PropTypes.string  // 'MM/DD/YYYY', 'DD/MM/YYYY', 'YYYY/MM/DD', 'DD-MM-YYYY'
   },
@@ -152,7 +153,8 @@ export default React.createClass({
       previousButtonElement: "<",
       nextButtonElement: ">",
       calendarPlacement: "bottom",
-      dateFormat: dateFormat
+      dateFormat: dateFormat,
+      disabled: false,
     }
   },
   getInitialState() {
@@ -190,6 +192,9 @@ export default React.createClass({
   },
 
   clear() {
+    if(this.props.disabled)
+      return;
+      
     if(this.props.onClear){
       this.props.onClear();
     }
@@ -383,15 +388,17 @@ export default React.createClass({
       onChange={this.onChangeMonth}
       monthLabels={this.props.monthLabels}
       dateFormat={this.props.dateFormat} />;
-    return <InputGroup ref="inputGroup" bsClass={this.props.bsClass} bsSize={this.props.bsSize} id={this.props.id ? this.props.id + "_group" : null}>
+    return <InputGroup disabled   ref="inputGroup" bsClass={this.props.bsClass} bsSize={this.props.bsSize} id={this.props.id ? this.props.id + "_group" : null}>
+      {!this.props.disabled && 
       <Overlay rootClose={true} onHide={this.handleHide} show={this.state.focused} container={() => this.props.calendarContainer || ReactDOM.findDOMNode(this.refs.overlayContainer)} target={() => ReactDOM.findDOMNode(this.refs.input)} placement={this.props.calendarPlacement} delayHide={200}>
         <Popover id="calendar" title={calendarHeader}>
           <Calendar cellPadding={this.props.cellPadding} selectedDate={this.state.selectedDate} displayDate={this.state.displayDate} onChange={this.onChangeDate} dayLabels={this.state.dayLabels} weekStartsOnMonday={this.props.weekStartsOnMonday} />
         </Popover>
-      </Overlay>
+      </Overlay>}
       <div ref="overlayContainer" />
-      <input ref="hiddenInput" type="hidden" id={this.props.id} name={this.props.name} value={this.state.value || ''} />
+      <input disabled={this.props.disabled} ref="hiddenInput" type="hidden" id={this.props.id} name={this.props.name} value={this.state.value || ''} />
       <FormControl
+        disabled={this.props.disabled}
         onKeyDown={this.handleKeyDown}
         value={this.state.inputValue || ''}
         ref="input"
@@ -401,7 +408,7 @@ export default React.createClass({
         onBlur={this.handleBlur}
         onChange={this.handleInputChange}
       />
-      <InputGroup.Addon onClick={this.clear} style={{cursor:this.state.inputValue ? "pointer" : "not-allowed"}}>{this.props.clearButtonElement}</InputGroup.Addon>
+      <InputGroup.Addon disabled={this.props.disabled} onClick={this.clear} style={{cursor:this.state.inputValue && !this.props.disabled ? "pointer" : "not-allowed"}}>{this.props.clearButtonElement}</InputGroup.Addon>
     </InputGroup>;
   }
 });

--- a/test/core.test.jsx
+++ b/test/core.test.jsx
@@ -427,4 +427,50 @@ describe("Date Picker", function() {
     assert.notEqual(document.querySelector("#calendarContainer #calendar"), null);
     ReactDOM.unmountComponentAtNode(container);
   }));
+  it("should not open the calendar and therefore not select a date.", co.wrap(function *(){
+    const id = UUID.v4();
+    const App = React.createClass({
+      render: function(){
+        return <div>
+          <DatePicker id={id} disabled/>
+        </div>;
+      }
+    });
+    yield new Promise(function(resolve, reject){
+      ReactDOM.render(<App />, container, resolve);
+    });
+    const hiddenInputElement = document.getElementById(id);
+    const inputElement = document.querySelector("input.form-control");
+    TestUtils.Simulate.focus(inputElement);
+    const dayElement = document.querySelector("table tbody tr:nth-child(2) td");
+    assert.equal(dayElement, null);
+    assert.equal(hiddenInputElement.value, '');
+    ReactDOM.unmountComponentAtNode(container);
+  }));
+
+  it("should not be able to click clear button", co.wrap(function *(){
+    const id = UUID.v4();
+    let value="12/12/2016"
+    const App = React.createClass({
+      handleChange: function(newValue){
+        value = newValue;
+      },
+      render: function(){
+        return <div>
+          <DatePicker id={id} value={value} disabled
+          onChange={this.handleChange} />
+        </div>;
+      }
+    });
+  
+    yield new Promise(function(resolve, reject){
+      ReactDOM.render(<App />, container, resolve);
+    });
+
+    const hiddenInputElement = document.getElementById(id)
+    const clearButtonElement = document.querySelector("span.input-group-addon");
+    TestUtils.Simulate.click(clearButtonElement);
+    assert.equal(value, "12/12/2016");
+    ReactDOM.unmountComponentAtNode(container);
+  }));
 });


### PR DESCRIPTION
I expanded on the disabled property which was implemented last week - it is no longer possible to clear the content by pressing the clearButton nor does the datepick "view" popup. 
It seemed to be this would be a better UX experience, deny this pull request if you think otherwise. 

This branch was developed in parallel, which might give merge conflicts(?). 

I added an example and tests. 
