### PR TITLE
Pass autoFocus prop to the FormControl

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ DatePicker component. Renders as a [React-Bootstrap InputGroup](https://react-bo
     * **Optional**
     * **Type:** `string`
     * **Example:** `"2016-05-19T16:00:00.000Z"`
+  * `autoFocus` - Whether or not component starts with focus.
+    * **Optional**
+    * **Type:** `bool`
+    * **Example:** `false`
   * `disabled` - Whether or not component is disabled.
     * **Optional**
     * **Type:** `bool`

--- a/lib/index.js
+++ b/lib/index.js
@@ -169,6 +169,7 @@ exports.default = _react2.default.createClass({
     monthLabels: _react2.default.PropTypes.array,
     onChange: _react2.default.PropTypes.func,
     onClear: _react2.default.PropTypes.func,
+    autoFocus: _react2.default.PropTypes.bool,
     disabled: _react2.default.PropTypes.bool,
     weekStartsOnMonday: _react2.default.PropTypes.bool,
     clearButtonElement: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.string, _react2.default.PropTypes.object]),
@@ -192,6 +193,7 @@ exports.default = _react2.default.createClass({
       calendarPlacement: "bottom",
       dateFormat: dateFormat,
       showClearButton: true,
+      autoFocus: false,
       disabled: false
     };
   },
@@ -449,6 +451,7 @@ exports.default = _react2.default.createClass({
         value: this.state.inputValue || '',
         ref: 'input',
         type: 'text',
+        autoFocus: this.props.autoFocus,
         disabled: this.props.disabled,
         placeholder: this.state.focused ? this.props.dateFormat : this.state.placeholder,
         onFocus: this.handleFocus,

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -123,6 +123,7 @@ export default React.createClass({
     monthLabels: React.PropTypes.array,
     onChange: React.PropTypes.func,
     onClear: React.PropTypes.func,
+    autoFocus: React.PropTypes.bool,
     disabled: React.PropTypes.bool,
     weekStartsOnMonday: React.PropTypes.bool,
     clearButtonElement: React.PropTypes.oneOfType([
@@ -157,6 +158,7 @@ export default React.createClass({
       calendarPlacement: "bottom",
       dateFormat: dateFormat,
       showClearButton: true,
+      autoFocus: false,
       disabled: false
     }
   },
@@ -401,6 +403,7 @@ export default React.createClass({
         value={this.state.inputValue || ''}
         ref="input"
         type="text"
+        autoFocus={this.props.autoFocus}
         disabled={this.props.disabled}
         placeholder={this.state.focused ? this.props.dateFormat : this.state.placeholder}
         onFocus={this.handleFocus}

--- a/test/core.test.jsx
+++ b/test/core.test.jsx
@@ -447,6 +447,40 @@ describe("Date Picker", function() {
     assert.notEqual(document.querySelector("#calendarContainer #calendar"), null);
     ReactDOM.unmountComponentAtNode(container);
   }));
+  it("should have no focus with autoFocus false.", co.wrap(function *(){
+    const id = UUID.v4();
+    const value = new Date().toISOString();
+    const App = React.createClass({
+      render: function(){
+        return <div>
+          <DatePicker id={id} value={value} autoFocus={false}/>
+        </div>;
+      }
+    });
+    yield new Promise(function(resolve, reject){
+      ReactDOM.render(<App />, container, resolve);
+    });
+    const inputElement = document.querySelector("input.form-control");
+    assert.notEqual(inputElement, document.activeElement);
+    ReactDOM.unmountComponentAtNode(container);
+  }));
+  it("should have focus with autoFocus true.", co.wrap(function *(){
+    const id = UUID.v4();
+    const value = new Date().toISOString();
+    const App = React.createClass({
+      render: function(){
+        return <div>
+          <DatePicker id={id} value={value} autoFocus={true}/>
+        </div>;
+      }
+    });
+    yield new Promise(function(resolve, reject){
+      ReactDOM.render(<App />, container, resolve);
+    });
+    const inputElement = document.querySelector("input.form-control");
+    assert.equal(inputElement, document.activeElement);
+    ReactDOM.unmountComponentAtNode(container);
+  }));
   it("should disable the input.", co.wrap(function *(){
     const id = UUID.v4();
     const value = new Date().toISOString();


### PR DESCRIPTION
I implemented `autoFocus` as a passthrough to the `FormControl`. Tests and documentation change also included.

It might be better to pass all unknown props through to the next level, like many react-bootstrap components do, but that would be a more involved change.