### PR TITLE
Make the overlay container position relative to fix placement

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -565,7 +565,7 @@ exports.default = _react2.default.createClass({
             todayButtonLabel: this.props.todayButtonLabel })
         )
       ),
-      _react2.default.createElement('div', { ref: 'overlayContainer' }),
+      _react2.default.createElement('div', { ref: 'overlayContainer', style: { position: 'relative' } }),
       _react2.default.createElement('input', { ref: 'hiddenInput', type: 'hidden', id: this.props.id, name: this.props.name, value: this.state.value || '', 'data-formattedvalue': this.state.value ? this.state.inputValue : '' }),
       control,
       this.props.showClearButton && !this.props.customControl && _react2.default.createElement(

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -539,7 +539,7 @@ export default React.createClass({
             todayButtonLabel={this.props.todayButtonLabel} />
         </Popover>
       </Overlay>
-      <div ref="overlayContainer" />
+      <div ref="overlayContainer" style={{position: 'relative'}} />
       <input ref="hiddenInput" type="hidden" id={this.props.id} name={this.props.name} value={this.state.value || ''} data-formattedvalue={this.state.value ? this.state.inputValue : ''} />
       {control}
       {this.props.showClearButton && !this.props.customControl && <InputGroup.Addon


### PR DESCRIPTION
Without a close button the popover overlay intersects the input. (I assume because there is no input group and it is contained in a bare span.) Making the position of the container div relative seems to fix this.

Illustration of the problem from running the example: http://imgur.com/a/1ssBk