### PR TITLE
InputGroup fixes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -550,6 +550,7 @@ exports.default = _react2.default.createClass({
         bsClass: this.props.showClearButton ? this.props.bsClass : '',
         bsSize: this.props.bsSize,
         id: this.props.id ? this.props.id + '_group' : null },
+      control,
       _react2.default.createElement(
         _reactBootstrap.Overlay,
         {
@@ -580,7 +581,6 @@ exports.default = _react2.default.createClass({
       ),
       _react2.default.createElement('div', { ref: 'overlayContainer', style: { position: 'relative' } }),
       _react2.default.createElement('input', { ref: 'hiddenInput', type: 'hidden', id: this.props.id, name: this.props.name, value: this.state.value || '', 'data-formattedvalue': this.state.value ? this.state.inputValue : '' }),
-      control,
       this.props.showClearButton && !this.props.customControl && _react2.default.createElement(
         _reactBootstrap.InputGroup.Addon,
         {
@@ -591,7 +591,8 @@ exports.default = _react2.default.createClass({
           { style: { opacity: this.state.inputValue && !this.props.disabled ? 1 : 0.5 } },
           this.props.clearButtonElement
         )
-      )
+      ),
+      this.props.children
     );
   }
 });

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -562,6 +562,7 @@ export default React.createClass({
           {this.props.clearButtonElement}
         </div>
       </InputGroup.Addon>}
+      {this.props.children}
     </InputGroup>;
   }
 });

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -532,6 +532,7 @@ export default React.createClass({
       bsClass={this.props.showClearButton ? this.props.bsClass : ''}
       bsSize={this.props.bsSize}
       id={this.props.id ? `${this.props.id}_group` : null}>
+      {control}
       <Overlay
         rootClose={true}
         onHide={this.handleHide}
@@ -554,7 +555,6 @@ export default React.createClass({
       </Overlay>
       <div ref="overlayContainer" style={{position: 'relative'}} />
       <input ref="hiddenInput" type="hidden" id={this.props.id} name={this.props.name} value={this.state.value || ''} data-formattedvalue={this.state.value ? this.state.inputValue : ''} />
-      {control}
       {this.props.showClearButton && !this.props.customControl && <InputGroup.Addon
         onClick={this.props.disabled ? null : this.clear}
         style={{cursor:(this.state.inputValue && !this.props.disabled) ? 'pointer' : 'not-allowed'}}>


### PR DESCRIPTION
@wehriam Hi!

This PR makes `<DatePicker>` be a bit of a better citizen inside `InputGroup`. It fixes two small things:
1. Makes the `FormControl` the first child of the `InputGroup`, so its corners get rounded properly and other Bootstrap niceties.
2. Allows users to pass children into the `<DatePicker>` component which will also be appended inside the input group. This allows you to do things like add more `InputGroup.Addon`s and allows the user a bit more customization to have the component fit into their application, at no cost to the DatePicker code.

Let me know what you think. Thanks!