### PR TITLE
Hide the clear button

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -581,14 +581,14 @@ exports.default = _react2.default.createClass({
       _react2.default.createElement('div', { ref: 'overlayContainer', style: { position: 'relative' } }),
       _react2.default.createElement('input', { ref: 'hiddenInput', type: 'hidden', id: this.props.id, name: this.props.name, value: this.state.value || '', 'data-formattedvalue': this.state.value ? this.state.inputValue : '' }),
       control,
-      this.props.showClearButton && !this.props.customControl && _react2.default.createElement(
+      this.props.showClearButton && !this.props.customControl && this.state.inputValue && _react2.default.createElement(
         _reactBootstrap.InputGroup.Addon,
         {
           onClick: this.props.disabled ? null : this.clear,
-          style: { cursor: this.state.inputValue && !this.props.disabled ? 'pointer' : 'not-allowed' } },
+          style: { cursor: this.props.disabled ? 'not-allowed' : 'pointer' } },
         _react2.default.createElement(
           'div',
-          { style: { opacity: this.state.inputValue && !this.props.disabled ? 1 : 0.5 } },
+          { style: { opacity: this.props.disabled ? 0.5 : 1 } },
           this.props.clearButtonElement
         )
       )

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -555,10 +555,10 @@ export default React.createClass({
       <div ref="overlayContainer" style={{position: 'relative'}} />
       <input ref="hiddenInput" type="hidden" id={this.props.id} name={this.props.name} value={this.state.value || ''} data-formattedvalue={this.state.value ? this.state.inputValue : ''} />
       {control}
-      {this.props.showClearButton && !this.props.customControl && <InputGroup.Addon
+      {this.props.showClearButton && !this.props.customControl && this.state.inputValue && <InputGroup.Addon
         onClick={this.props.disabled ? null : this.clear}
-        style={{cursor:(this.state.inputValue && !this.props.disabled) ? 'pointer' : 'not-allowed'}}>
-        <div style={{opacity: (this.state.inputValue && !this.props.disabled) ? 1 : 0.5}}>
+        style={{cursor:this.props.disabled ? 'not-allowed' : 'pointer'}}>
+        <div style={{opacity: this.props.disabled ? 0.5 : 1}}>
           {this.props.clearButtonElement}
         </div>
       </InputGroup.Addon>}


### PR DESCRIPTION
@wehriam Hi again!

This one's potentially a little more controversial. It basically just hides the close button if there is no value in the DatePicker. I have it set to be the default behavior, but I'd also be open to putting this behind an option.

What do you think?