### PR TITLE
Import bootstrap components from lib folder

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -2,13 +2,11 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {
-  Button,
-  FormControl,
-  InputGroup,
-  Overlay,
-  Popover,
-} from 'react-bootstrap';
+import Button from 'react-bootstrap/lib/Button';
+import FormControl from 'react-bootstrap/lib/FormControl';
+import InputGroup from 'react-bootstrap/lib/InputGroup';
+import Overlay from 'react-bootstrap/lib/Overlay';
+import Popover from 'react-bootstrap/lib/Popover';
 
 let instanceCount = 0;
 


### PR DESCRIPTION
From the react-bootstrap docs:

> If you install React-Bootstrap using npm, you can import individual components from react-bootstrap/lib rather than the entire library. Doing so pulls in only the specific components that you use, which can significantly reduce the size of your client bundle.

Since datepicker only relies on a few bootstrap components we can save up to ~115kb by changing the import syntax so that we don't require the entire react-bootstrap library.
Thoughts?