### PR TITLE
Reset date to 1, setMonth wraps if date larger

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -31,12 +31,14 @@ const CalendarHeader = React.createClass({
 
   handleClickPrevious() {
     const newDisplayDate = new Date(this.props.displayDate);
+    newDisplayDate.setDate(1);
     newDisplayDate.setMonth(newDisplayDate.getMonth() - 1);
     this.props.onChange(newDisplayDate);
   },
 
   handleClickNext() {
     const newDisplayDate = new Date(this.props.displayDate);
+    newDisplayDate.setDate(1);
     newDisplayDate.setMonth(newDisplayDate.getMonth() + 1);
     this.props.onChange(newDisplayDate);
   },


### PR DESCRIPTION
Addressing issue highlighted in #84. Clicking next month can cause skips to occur, if the maximum date of the next month is less than the date of the selected month. 