### PR TITLE
Update webpack configs for webpack v2

### DIFF
--- a/example/webpack.example.config.js
+++ b/example/webpack.example.config.js
@@ -10,10 +10,10 @@ module.exports = {
     filename: 'bundle.js'
   },
   resolve: {
-    extensions: ['', '.js', '.jsx']
+    extensions: ['.js', '.jsx']
   },
   module: {
-    loaders: [
+    rules: [
       {
         exclude: /node_modules/,
         loader: 'babel-loader',

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -91,11 +91,11 @@ module.exports = function (karma) {
     singleRun: true,
     webpack: {
       resolve: {
-        extensions: ['', '.js', '.jsx']
+        extensions: ['.js', '.jsx']
       },
       devtool: 'inline-source-map',
       module: {
-        loaders: [
+        rules: [
           {
             exclude: /(node_modules|lib|example)/,
             loader: 'babel-loader',
@@ -106,7 +106,7 @@ module.exports = function (karma) {
             test: /\.jsx?$/
           }, {
             include: path.resolve('src'),
-            loader: 'isparta',
+            loader: 'isparta-loader',
             test: /\.jsx?$/
           }
         ]


### PR DESCRIPTION
Since webpack 2 is the current stable version, and the webpack dependency is listed as `'*'` then npm will now install version 2 which doesn't work with the current configurations. Since it was a fairly easy update to get it working I figured I would submit a PR.

Thanks!