### PR TITLE
Removed dayLabels from state

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -317,16 +317,18 @@ exports.default = _react2.default.createClass({
       throw new Error('Conflicting DatePicker properties \'value\' and \'defaultValue\'');
     }
     var state = this.makeDateValues(this.props.value || this.props.defaultValue);
-    if (this.props.weekStartsOnMonday) {
-      state.dayLabels = this.props.dayLabels.slice(1).concat(this.props.dayLabels.slice(0, 1));
-    } else {
-      state.dayLabels = this.props.dayLabels;
-    }
     state.focused = false;
     state.inputFocused = false;
     state.placeholder = this.props.placeholder || this.props.dateFormat;
     state.separator = this.props.dateFormat.match(/[^A-Z]/)[0];
     return state;
+  },
+  getDayLabels: function getDayLabels() {
+    if (this.props.weekStartsOnMonday) {
+      return this.props.dayLabels.slice(1).concat(this.props.dayLabels.slice(0, 1));
+    } else {
+      return this.props.dayLabels;
+    }
   },
   makeDateValues: function makeDateValues(isoString) {
     var displayDate = void 0;
@@ -624,7 +626,7 @@ exports.default = _react2.default.createClass({
             selectedDate: this.state.selectedDate,
             displayDate: this.state.displayDate,
             onChange: this.onChangeDate,
-            dayLabels: this.state.dayLabels,
+            dayLabels: this.getDayLabels(),
             weekStartsOnMonday: this.props.weekStartsOnMonday,
             showTodayButton: this.props.showTodayButton,
             todayButtonLabel: this.props.todayButtonLabel,

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -266,16 +266,19 @@ export default React.createClass({
       throw new Error('Conflicting DatePicker properties \'value\' and \'defaultValue\'');
     }
     const state = this.makeDateValues(this.props.value || this.props.defaultValue);
-    if (this.props.weekStartsOnMonday) {
-      state.dayLabels = this.props.dayLabels.slice(1).concat(this.props.dayLabels.slice(0,1));
-    } else {
-      state.dayLabels = this.props.dayLabels;
-    }
     state.focused = false;
     state.inputFocused = false;
     state.placeholder = this.props.placeholder || this.props.dateFormat;
     state.separator = this.props.dateFormat.match(/[^A-Z]/)[0];
     return state;
+  },
+
+  getDayLabels() {
+    if (this.props.weekStartsOnMonday) {
+      return this.props.dayLabels.slice(1).concat(this.props.dayLabels.slice(0,1));
+    } else {
+      return this.props.dayLabels;
+    }
   },
 
   makeDateValues(isoString) {
@@ -577,7 +580,7 @@ export default React.createClass({
             selectedDate={this.state.selectedDate}
             displayDate={this.state.displayDate}
             onChange={this.onChangeDate}
-            dayLabels={this.state.dayLabels}
+            dayLabels={this.getDayLabels()}
             weekStartsOnMonday={this.props.weekStartsOnMonday}
             showTodayButton={this.props.showTodayButton}
             todayButtonLabel={this.props.todayButtonLabel}


### PR DESCRIPTION
This change fixes situation where dayLabels prop changes, but it's
already present in the state, so it doesn't change in UI. This can
happen when using some translations library, like react-i18next.

Fixes #91 

Signed-off-by: Jakub Koudelka <koudelka.j@gmail.com>