### PR TITLE
Allows a function to be passed to calendarPlacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ DatePicker component. Renders as a [React-Bootstrap InputGroup](https://react-bo
     * **Example:** `['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']`
   * `calendarPlacement` - Overlay placement for the popover calendar.
     * **Optional**
-    * **Type:** `string`
+    * **Type:** `string` or `function`
     * **Example:** `"top"`
   * `calendarContainer` - Overlay container for the popover calendar. When placing the date-picker in a scrolling container, set this prop to some ancestor of the scrolling container.
     * **Optional**

--- a/example/app.jsx
+++ b/example/app.jsx
@@ -42,6 +42,22 @@ const App = React.createClass({
       maxDate: value
     });
   },
+  handlePlacement() {
+    return 'top';
+  },
+  handleRandomPlacement() {
+    const placementKey = Math.floor((Math.random()*4) + 1);
+    switch (placementKey) {
+      case 1:
+        return 'top';
+      case 2:
+        return 'left';
+      case 4:
+        return 'right';
+      default:
+        return 'bottom';
+    }
+  },
   render() {
     const LabelISOString = new Date().toISOString();
     return <Grid>
@@ -309,6 +325,22 @@ const App = React.createClass({
             <ControlLabel>Left</ControlLabel>
             <DatePicker placeholder="Placeholder" calendarPlacement="left" />
             <HelpBlock>Help</HelpBlock>
+          </FormGroup>
+        </Col>
+      </Row>
+      <Row>
+        <Col sm={6}>
+          <FormGroup>
+            <ControlLabel>Placement determined by function</ControlLabel>
+            <DatePicker placeholder="Placeholder" calendarPlacement={this.handlePlacement} />
+            <HelpBlock>Placed at top</HelpBlock>
+          </FormGroup>
+        </Col>
+        <Col sm={6}>
+          <FormGroup>
+            <ControlLabel>Random placement</ControlLabel>
+            <DatePicker placeholder="Placeholder" calendarPlacement={this.handleRandomPlacement} />
+            <HelpBlock>Placement is random in either of the four directions</HelpBlock>
           </FormGroup>
         </Col>
       </Row>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -250,7 +250,10 @@ export default React.createClass({
       React.PropTypes.string,
       React.PropTypes.object
     ]),
-    calendarPlacement: React.PropTypes.string,
+    calendarPlacement: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.func
+    ]),
     dateFormat: React.PropTypes.string, // 'MM/DD/YYYY', 'DD/MM/YYYY', 'YYYY/MM/DD', 'DD-MM-YYYY'
     bsClass: React.PropTypes.string,
     bsSize: React.PropTypes.string,
@@ -393,9 +396,12 @@ export default React.createClass({
       return;
     }
 
+    const placement = this.getCalendarPlacement();
+
     this.setState({
       inputFocused: true,
-      focused: true
+      focused: true,
+      calendarPlacement: placement
     });
 
     if (this.props.onFocus) {
@@ -422,6 +428,17 @@ export default React.createClass({
 
   getFormattedValue() {
     return this.state.displayDate ? this.state.inputValue : null;
+  },
+
+  getCalendarPlacement() {
+    const tag = Object.prototype.toString.call(this.props.calendarPlacement);
+    const isFunction = tag === '[object AsyncFunction]' || tag === '[object Function]' || tag === '[object GeneratorFunction]' || tag === '[object Proxy]';
+    if (isFunction) {
+      return this.props.calendarPlacement();
+    }
+    else {
+      return this.props.calendarPlacement;
+    }
   },
 
   makeInputValueString(date) {
@@ -620,7 +637,7 @@ export default React.createClass({
         show={this.state.focused}
         container={() => this.props.calendarContainer || ReactDOM.findDOMNode(this.refs.overlayContainer)}
         target={() => ReactDOM.findDOMNode(this.refs.input)}
-        placement={this.props.calendarPlacement}
+        placement={this.state.calendarPlacement}
         delayHide={200}>
         <Popover id={`date-picker-popover-${this.props.instanceCount}`} className="date-picker-popover" title={calendarHeader}>
           <Calendar

--- a/test/core.test.jsx
+++ b/test/core.test.jsx
@@ -1061,4 +1061,41 @@ describe("Date Picker", function() {
     assert.equal(document.querySelector("table thead tr:first-child td small").innerHTML, "Sat");
     ReactDOM.unmountComponentAtNode(container);
   }));
+  it("should allow for a string to determine calendar placement", co.wrap(function *(){
+    const id = UUID.v4();
+    const App = React.createClass({
+      render: function(){
+        return <div>
+          <DatePicker id={id} calendarPlacement="right" />
+        </div>;
+      }
+    });
+    yield new Promise(function(resolve, reject){
+      ReactDOM.render(<App />, container, resolve);
+    });
+    const inputElement = document.querySelector("input.form-control");
+    TestUtils.Simulate.focus(inputElement);
+    const popover = document.querySelector(".date-picker-popover.right");
+    assert.notEqual(popover, null);
+  }));
+  it("should allow for a function to determine calendar placement", co.wrap(function *(){
+    const id = UUID.v4();
+    const App = React.createClass({
+      handlePlacement(){
+        return "top";
+      },
+      render: function(){
+        return <div>
+          <DatePicker id={id} calendarPlacement={this.handlePlacement} />
+        </div>;
+      }
+    });
+    yield new Promise(function(resolve, reject){
+      ReactDOM.render(<App />, container, resolve);
+    });
+    const inputElement = document.querySelector("input.form-control");
+    TestUtils.Simulate.focus(inputElement);
+    const popover = document.querySelector(".date-picker-popover.top");
+    assert.notEqual(popover, null);
+  }));
 });

--- a/test/core.test.jsx
+++ b/test/core.test.jsx
@@ -1077,6 +1077,7 @@ describe("Date Picker", function() {
     TestUtils.Simulate.focus(inputElement);
     const popover = document.querySelector(".date-picker-popover.right");
     assert.notEqual(popover, null);
+    ReactDOM.unmountComponentAtNode(container);
   }));
   it("should allow for a function to determine calendar placement", co.wrap(function *(){
     const id = UUID.v4();
@@ -1097,5 +1098,6 @@ describe("Date Picker", function() {
     TestUtils.Simulate.focus(inputElement);
     const popover = document.querySelector(".date-picker-popover.top");
     assert.notEqual(popover, null);
+    ReactDOM.unmountComponentAtNode(container);
   }));
 });


### PR DESCRIPTION
This property change allows a function to be passed to calendarPlacement in addition to a string. This fixes #104.

## Description
- Implemented a getCalendarPlacement method that executes the function that is passed by props, if present, or returns the string value. The React.PropTypes validation ensures that those are the only two possible types. 
- The getCalendarPlacement function is executed in the onFocus handler (handleFocus) where the focused state is set to true. I did this so as to avoid recalculating calling the function in unnecessary scenarios (like when the pop-up is closing).
- Added 2 tests, one testing using a string to set the calendar placement and another test uses a function.
- Updated example app and documentation.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is explained in further detail in #104 

## How Has This Been Tested?
Tested on the following with all unit tests passing:
- Chrome 56.0.2924 (Mac OS X 10.12.4)
- Safari 10.1.0 (Mac OS X 10.12.4)

I also created two scenarios in the example app showcasing the functionality, and where one can see that previous functionality remains intact.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (let me know if something is amiss!)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
