### PR TITLE
Add tabindex attribute to input element

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,10 @@ DatePicker component. Renders as a [React-Bootstrap InputGroup](https://react-bo
     * **Optional**
     * **Type:** `React.Component`
     * **Example:** `<CustomControl />`
+  * `tabIndex` - The tabIndex specifies the tab order of the input element. If a `customControl` is used, this property is passed down to it as well.
+    * **Optional**
+    * **Type:** `number`
+    * **Example:** `2`
 
 * **Methods:**
 

--- a/example/app.jsx
+++ b/example/app.jsx
@@ -390,6 +390,41 @@ const App = React.createClass({
           </FormGroup>
         </Col>
       </Row>
+      <Row>
+        <Col xs={12}>
+          <h2>Tab Indexes</h2>
+        </Col>
+      </Row>
+      <Row>
+        <Col sm={3}>
+          <FormGroup>
+            <ControlLabel>Third</ControlLabel>
+            <DatePicker placeholder="Placeholder" tabIndex={103} />
+            <HelpBlock>The focus will jump here after Second</HelpBlock>
+          </FormGroup>
+        </Col>
+        <Col sm={3}>
+          <FormGroup>
+            <ControlLabel>Second</ControlLabel>
+            <DatePicker placeholder="Placeholder" tabIndex={102} />
+            <HelpBlock>The focus will jump here after First.</HelpBlock>
+          </FormGroup>
+        </Col>
+        <Col sm={3}>
+          <FormGroup>
+            <ControlLabel>Fourth</ControlLabel>
+            <DatePicker placeholder="Placeholder" tabIndex={104} />
+            <HelpBlock>The focus will jump here after Third</HelpBlock>
+          </FormGroup>
+        </Col>
+        <Col sm={3}>
+          <FormGroup>
+            <ControlLabel>First</ControlLabel>
+            <DatePicker placeholder="Placeholder" tabIndex={101} />
+            <HelpBlock>Focus on this element to start!</HelpBlock>
+          </FormGroup>
+        </Col>
+      </Row>
     </Grid>;
   }
 });

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -265,7 +265,8 @@ export default React.createClass({
     children: React.PropTypes.oneOfType([
       React.PropTypes.arrayOf(React.PropTypes.node),
       React.PropTypes.node
-    ])
+    ]),
+    tabIndex: React.PropTypes.number
   },
 
   getDefaultProps() {
@@ -590,6 +591,7 @@ export default React.createClass({
         className: this.props.className,
         style: this.props.style,
         autoComplete: this.props.autoComplete,
+        tabIndex: this.props.tabIndex
       })
       : <FormControl
           onKeyDown={this.handleKeyDown}
@@ -606,6 +608,7 @@ export default React.createClass({
           onBlur={this.handleBlur}
           onChange={this.handleInputChange}
           autoComplete={this.props.autoComplete}
+          tabIndex={this.props.tabIndex}
           />;
 
     return <InputGroup

--- a/test/core.test.jsx
+++ b/test/core.test.jsx
@@ -1061,4 +1061,22 @@ describe("Date Picker", function() {
     assert.equal(document.querySelector("table thead tr:first-child td small").innerHTML, "Sat");
     ReactDOM.unmountComponentAtNode(container);
   }));
+  it("should set a tabindex on the input control", co.wrap(function *(){
+    const id = UUID.v4();
+    const App = React.createClass({
+      render: function(){
+        return <div>
+          <DatePicker id={id} tabIndex={101} />
+        </div>;
+      }
+    });
+    yield new Promise(function(resolve, reject){
+      ReactDOM.render(<App />, container, resolve);
+    });
+    const inputElement = document.querySelector("input.form-control");
+    TestUtils.Simulate.focus(inputElement);
+    assert.notEqual(inputElement, null);
+    assert.equal(inputElement.getAttribute('tabindex'), 101);
+    ReactDOM.unmountComponentAtNode(container);
+  }));
 });


### PR DESCRIPTION
Fix for #76

<!--- Provide a general summary of your changes in the Title above -->

## Description
- Added unit test for tab index
- Added documentation
- Added examples

## Motivation and Context
Be able to set the tabindex on the datepicker to control the tab ordering in a form.

## How Has This Been Tested?
Ran the unit tests and also tested it on the example application.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
