### PR TITLE
Adding new property todayDate

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,10 @@ DatePicker component. Renders as a [React-Bootstrap InputGroup](https://react-bo
     * **Optional**
     * **Type:** `React.Component`
     * **Example:** `<CustomControl />`
+  * `todayDate` - Change today's date to a past or future date
+    * **Optional**
+    * **Type:** `string`
+    * **Example:** `"MM/DD/YYYY"`, `"YYYY/MM/DD"`, `"MM-DD-YYYY"`, or `"DD MM YYYY"`
 
 * **Methods:**
 

--- a/example/app.jsx
+++ b/example/app.jsx
@@ -24,7 +24,8 @@ const App = React.createClass({
       previousDate: null,
       minDate: null,
       maxDate: null,
-      focused: false
+      focused: false,
+      todayDate: new Date('2017', '0', '1').toISOString()
     };
   },
   handleChange(value) {
@@ -59,7 +60,6 @@ const App = React.createClass({
     }
   },
   render() {
-    const LabelISOString = new Date().toISOString();
     return <Grid>
       <Row>
         <Col xs={12}>
@@ -207,7 +207,7 @@ const App = React.createClass({
           <FormGroup>
             <ControlLabel>Min</ControlLabel>
             <DatePicker onChange={this.handleMinChange} value={this.state.minDate} />
-            <HelpBlock>{`Configure Example minDate`}</HelpBlock>
+            <HelpBlock>Configure Example minDate</HelpBlock>
             <HelpBlock>{`value: ${this.state.minDate}`}</HelpBlock>
           </FormGroup>
         </Col>
@@ -215,7 +215,7 @@ const App = React.createClass({
           <FormGroup>
             <ControlLabel>Max</ControlLabel>
             <DatePicker onChange={this.handleMaxChange} value={this.state.maxDate} />
-            <HelpBlock>{`Configure Example maxDate`}</HelpBlock>
+            <HelpBlock>Configure Example maxDate</HelpBlock>
             <HelpBlock>{`value: ${this.state.maxDate}`}</HelpBlock>
           </FormGroup>
         </Col>
@@ -286,10 +286,17 @@ const App = React.createClass({
             <DatePicker weekStartsOn={4} />
           </FormGroup>
         </Col>
-        <Col sm={6}>
+        <Col sm={3}>
           <FormGroup>
             <ControlLabel>Control Element</ControlLabel>
             <DatePicker customControl={<CustomControl />} />
+          </FormGroup>
+        </Col>
+        <Col sm={3}>
+          <FormGroup>
+            <ControlLabel>Today Date</ControlLabel>
+            <DatePicker showTodayButton todayDate={this.state.todayDate} />
+            <HelpBlock>Today's date is set to 01/01/2017</HelpBlock>
           </FormGroup>
         </Col>
       </Row>
@@ -428,7 +435,10 @@ const App = React.createClass({
 
 const CustomControl = React.createClass({
   displayName: 'CustomControl',
-
+  propTypes: {
+    value: React.PropTypes.string,
+    placeholder: React.PropTypes.string
+  },
   render() {
     const {
       value,

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -88,7 +88,8 @@ const Calendar = React.createClass({
     weekStartsOn: React.PropTypes.number,
     showTodayButton: React.PropTypes.bool,
     todayButtonLabel: React.PropTypes.string,
-    roundedCorners: React.PropTypes.bool
+    roundedCorners: React.PropTypes.bool,
+    todayDate: React.PropTypes.string
   },
 
   handleClick(day) {
@@ -98,7 +99,7 @@ const Calendar = React.createClass({
   },
 
   handleClickToday() {
-    const newSelectedDate = this.setTimeToNoon(new Date());
+    const newSelectedDate = this.setTimeToNoon(this.props.todayDate ? new Date(this.props.todayDate) : new Date());
     this.props.onChange(newSelectedDate);
   },
 
@@ -268,7 +269,8 @@ export default React.createClass({
     children: React.PropTypes.oneOfType([
       React.PropTypes.arrayOf(React.PropTypes.node),
       React.PropTypes.node
-    ])
+    ]),
+    todayDate: React.PropTypes.string
   },
 
   getDefaultProps() {
@@ -330,7 +332,8 @@ export default React.createClass({
     if (selectedDate) {
       displayDate = new Date(selectedDate);
     } else {
-      const today = new Date(`${(new Date().toISOString().slice(0,10))}T12:00:00.000Z`);
+      const today = this.props.todayDate ? new Date(`${this.props.todayDate.slice(0,10)}T12:00:00.000Z`)
+      : new Date(`${(new Date().toISOString().slice(0,10))}T12:00:00.000Z`);
       if (minDate && Date.parse(minDate) >= Date.parse(today)){
         displayDate = minDate;
       } else if (maxDate && Date.parse(maxDate) <= Date.parse(today)){
@@ -657,6 +660,7 @@ export default React.createClass({
             minDate={this.props.minDate}
             maxDate={this.props.maxDate}
             roundedCorners={this.props.roundedCorners}
+            todayDate={this.props.todayDate}
            />
         </Popover>
       </Overlay>


### PR DESCRIPTION
## Description
Is it useful to have a property to change the default display date on the popover component, some times, we need the popover to open on a different month or year to be closer to a specific date range.

## Motivation and Context
I'm using the component to select some dates in the past, 3 or 4 years in the past, in those cases, it is painful to navigate between years every time. Changing the todayDate we can make it easier.

## How Has This Been Tested?
Tests were made in browser through UI.
Tested on MacOS Sierra, Chrome 57.0.2987.98 (64-bit) 

## Screenshots:


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.

*tests are already failing
