### PR TITLE
Fixes deprecation warnings introduced in React 15.5.0

### DIFF
--- a/example/app.jsx
+++ b/example/app.jsx
@@ -11,13 +11,14 @@ import Glyphicon from 'react-bootstrap/lib/Glyphicon';
 import FormGroup from 'react-bootstrap/lib/FormGroup';
 import ControlLabel from 'react-bootstrap/lib/ControlLabel';
 import HelpBlock from 'react-bootstrap/lib/HelpBlock';
+import createReactClass from 'create-react-class';
 
 const spanishDayLabels = ['Dom', 'Lu', 'Ma', 'Mx', 'Ju', 'Vi', 'Sab'];
 const spanishMonthLabels = ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre'];
 const wapperDivStyle = { border: '1px solid #ccc' };
 const scrollingDivStyle = { padding: '10px', height: '70px', overflow: 'auto' };
 
-const App = React.createClass({
+const App = createReactClass({
   getInitialState() {
     return {
       date: new Date().toISOString(),
@@ -426,7 +427,7 @@ const App = React.createClass({
   }
 });
 
-const CustomControl = React.createClass({
+const CustomControl = createReactClass({
   displayName: 'CustomControl',
 
   render() {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "peerDependencies": {
     "react": ">=0.14.0",
-    "react-bootstrap": "^0.30.8"
+    "react-bootstrap": "^0.31.0"
   },
   "devDependencies": {
     "assert": "^1.4.1",
@@ -31,6 +31,7 @@
     "babel-preset-react": "^6.23.0",
     "babel-preset-stage-1": "^6.22.0",
     "co": "^4.6.0",
+    "create-react-class": "^15.5.2",
     "doctoc": "^1.3.0",
     "envify": "^4.0.0",
     "es6-promise": "^4.1.0",
@@ -52,10 +53,10 @@
     "mocha": "^3.2.0",
     "mocha-babel": "^3.0.3",
     "node-uuid": "^1.4.7",
-    "react": "^15.4.2",
-    "react-addons-test-utils": "^15.4.2",
-    "react-bootstrap": "^0.30.8",
-    "react-dom": "^15.4.2",
+    "prop-types": "^15.5.8",
+    "react": "^15.5.4",
+    "react-bootstrap": "^0.31.0",
+    "react-dom": "^15.5.4",
     "regenerator": "^0.8.46",
     "regenerator-loader": "^3.1.0",
     "transform-loader": "^0.2.4",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -7,25 +7,27 @@ import FormControl from 'react-bootstrap/lib/FormControl';
 import InputGroup from 'react-bootstrap/lib/InputGroup';
 import Overlay from 'react-bootstrap/lib/Overlay';
 import Popover from 'react-bootstrap/lib/Popover';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 
 let instanceCount = 0;
 
-const CalendarHeader = React.createClass({
+const CalendarHeader = createReactClass({
   displayName: 'DatePickerHeader',
 
   propTypes: {
-    displayDate: React.PropTypes.object.isRequired,
-    minDate: React.PropTypes.string,
-    maxDate: React.PropTypes.string,
-    onChange: React.PropTypes.func.isRequired,
-    monthLabels: React.PropTypes.array.isRequired,
-    previousButtonElement: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.object
+    displayDate: PropTypes.object.isRequired,
+    minDate: PropTypes.string,
+    maxDate: PropTypes.string,
+    onChange: PropTypes.func.isRequired,
+    monthLabels: PropTypes.array.isRequired,
+    previousButtonElement: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object
     ]).isRequired,
-    nextButtonElement: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.object
+    nextButtonElement: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object
     ]).isRequired,
   },
 
@@ -74,21 +76,21 @@ const CalendarHeader = React.createClass({
 
 const daysInMonth = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 
-const Calendar = React.createClass({
+const Calendar = createReactClass({
   displayName: 'DatePickerCalendar',
 
   propTypes: {
-    selectedDate: React.PropTypes.object,
-    displayDate: React.PropTypes.object.isRequired,
-    minDate: React.PropTypes.string,
-    maxDate: React.PropTypes.string,
-    onChange: React.PropTypes.func.isRequired,
-    dayLabels: React.PropTypes.array.isRequired,
-    cellPadding: React.PropTypes.string.isRequired,
-    weekStartsOn: React.PropTypes.number,
-    showTodayButton: React.PropTypes.bool,
-    todayButtonLabel: React.PropTypes.string,
-    roundedCorners: React.PropTypes.bool
+    selectedDate: PropTypes.object,
+    displayDate: PropTypes.object.isRequired,
+    minDate: PropTypes.string,
+    maxDate: PropTypes.string,
+    onChange: PropTypes.func.isRequired,
+    dayLabels: PropTypes.array.isRequired,
+    cellPadding: PropTypes.string.isRequired,
+    weekStartsOn: PropTypes.number,
+    showTodayButton: PropTypes.bool,
+    todayButtonLabel: PropTypes.string,
+    roundedCorners: PropTypes.bool
   },
 
   handleClick(day) {
@@ -209,65 +211,65 @@ const Calendar = React.createClass({
   }
 });
 
-export default React.createClass({
+export default createReactClass({
   displayName: 'DatePicker',
 
   propTypes: {
-    defaultValue: React.PropTypes.string,
-    value: React.PropTypes.string,
-    required: React.PropTypes.bool,
-    className: React.PropTypes.string,
-    style: React.PropTypes.object,
-    minDate: React.PropTypes.string,
-    maxDate: React.PropTypes.string,
-    cellPadding: React.PropTypes.string,
-    autoComplete: React.PropTypes.string,
-    placeholder: React.PropTypes.string,
-    dayLabels: React.PropTypes.array,
-    monthLabels: React.PropTypes.array,
-    onChange: React.PropTypes.func,
-    onClear: React.PropTypes.func,
-    onBlur: React.PropTypes.func,
-    onFocus: React.PropTypes.func,
-    autoFocus: React.PropTypes.bool,
-    disabled: React.PropTypes.bool,
+    defaultValue: PropTypes.string,
+    value: PropTypes.string,
+    required: PropTypes.bool,
+    className: PropTypes.string,
+    style: PropTypes.object,
+    minDate: PropTypes.string,
+    maxDate: PropTypes.string,
+    cellPadding: PropTypes.string,
+    autoComplete: PropTypes.string,
+    placeholder: PropTypes.string,
+    dayLabels: PropTypes.array,
+    monthLabels: PropTypes.array,
+    onChange: PropTypes.func,
+    onClear: PropTypes.func,
+    onBlur: PropTypes.func,
+    onFocus: PropTypes.func,
+    autoFocus: PropTypes.bool,
+    disabled: PropTypes.bool,
     weekStartsOnMonday: (props, propName, componentName) => {
       if (props[propName]) {
         return new Error(`Prop '${propName}' supplied to '${componentName}' is obsolete. Use 'weekStartsOn' instead.`);
       }
     },
-    weekStartsOn: React.PropTypes.number,
-    clearButtonElement: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.object
+    weekStartsOn: PropTypes.number,
+    clearButtonElement: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object
     ]),
-    showClearButton: React.PropTypes.bool,
-    previousButtonElement: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.object
+    showClearButton: PropTypes.bool,
+    previousButtonElement: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object
     ]),
-    nextButtonElement: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.object
+    nextButtonElement: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object
     ]),
-    calendarPlacement: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.func
+    calendarPlacement: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.func
     ]),
-    dateFormat: React.PropTypes.string, // 'MM/DD/YYYY', 'DD/MM/YYYY', 'YYYY/MM/DD', 'DD-MM-YYYY'
-    bsClass: React.PropTypes.string,
-    bsSize: React.PropTypes.string,
-    calendarContainer: React.PropTypes.object,
-    id: React.PropTypes.string,
-    name: React.PropTypes.string,
-    showTodayButton: React.PropTypes.bool,
-    todayButtonLabel: React.PropTypes.string,
-    instanceCount: React.PropTypes.number,
-    customControl: React.PropTypes.object,
-    roundedCorners: React.PropTypes.bool,
-    children: React.PropTypes.oneOfType([
-      React.PropTypes.arrayOf(React.PropTypes.node),
-      React.PropTypes.node
+    dateFormat: PropTypes.string, // 'MM/DD/YYYY', 'DD/MM/YYYY', 'YYYY/MM/DD', 'DD-MM-YYYY'
+    bsClass: PropTypes.string,
+    bsSize: PropTypes.string,
+    calendarContainer: PropTypes.object,
+    id: PropTypes.string,
+    name: PropTypes.string,
+    showTodayButton: PropTypes.bool,
+    todayButtonLabel: PropTypes.string,
+    instanceCount: PropTypes.number,
+    customControl: PropTypes.object,
+    roundedCorners: PropTypes.bool,
+    children: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.node),
+      PropTypes.node
     ])
   },
 

--- a/test/core.test.jsx
+++ b/test/core.test.jsx
@@ -5,7 +5,8 @@ import assert from "assert";
 import co from "co";
 import ES6Promise from 'es6-promise';
 import UUID from "node-uuid";
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
+import createReactClass from 'create-react-class';
 
 ES6Promise.polyfill();
 
@@ -37,7 +38,7 @@ describe("Date Picker", function() {
   });
   it("should render an empty date picker.", co.wrap(function *(){
     const id = UUID.v4();
-    const App = React.createClass({
+    const App = createReactClass({
       render: function(){
         return <div>
           <DatePicker id={id} />
@@ -55,7 +56,7 @@ describe("Date Picker", function() {
   it("should render a date picker with a value.", co.wrap(function *(){
     const id = UUID.v4();
     const value = `${new Date().toISOString().slice(0,10)}T12:00:00.000Z`;
-    const App = React.createClass({
+    const App = createReactClass({
       render: function(){
         return <div>
           <DatePicker id={id} value={value} />
@@ -72,7 +73,7 @@ describe("Date Picker", function() {
   }));
   it("should open the calendar and select a date.", co.wrap(function *(){
     const id = UUID.v4();
-    const App = React.createClass({
+    const App = createReactClass({
       render: function(){
         return <div>
           <DatePicker id={id} />
@@ -97,7 +98,7 @@ describe("Date Picker", function() {
     const id = UUID.v4();
     let value = null;
     let formattedValue = null;
-    const App = React.createClass({
+    const App = createReactClass({
       handleChange: function(newValue, newFormattedValue){
         value = newValue;
         formattedValue = newFormattedValue;
@@ -124,7 +125,7 @@ describe("Date Picker", function() {
   it("should open the calendar and render 29 days on a leap year.", co.wrap(function *(){
     const id = UUID.v4();
     let value = "2016-02-15T00:00:00.000Z";
-    const App = React.createClass({
+    const App = createReactClass({
       render: function(){
         return <div>
           <DatePicker id={id} value={value} />
@@ -145,7 +146,7 @@ describe("Date Picker", function() {
     const id = UUID.v4();
     let value = null;
     let formattedValue = null;
-    const App = React.createClass({
+    const App = createReactClass({
       handleChange: function(newValue, newFormattedValue){
         value = newValue;
         formattedValue = newFormattedValue;
@@ -174,7 +175,7 @@ describe("Date Picker", function() {
     const clearButtonElement = <div id="clear-button-element"></div>;
     const previousButtonElement = <div id="previous-button-element"></div>;
     const nextButtonElement = <div id="next-button-element"></div>;
-    const App = React.createClass({
+    const App = createReactClass({
       render: function(){
         return <div>
           <DatePicker
@@ -206,7 +207,7 @@ describe("Date Picker", function() {
   it("should render without clear button element", co.wrap(function *(){
     const id = UUID.v4();
     const clearButtonElement = <div id="clear-button-element"></div>;
-    const App = React.createClass({
+    const App = createReactClass({
       render: function(){
         return <div>
           <DatePicker
@@ -225,7 +226,7 @@ describe("Date Picker", function() {
   }));
   it("should go to the previous and next month.", co.wrap(function *(){
     const id = UUID.v4();
-    const App = React.createClass({
+    const App = createReactClass({
       render: function(){
         return <div>
           <DatePicker id={id} />
@@ -253,7 +254,7 @@ describe("Date Picker", function() {
   }));
   it("should cycle through every month in the year.", co.wrap(function *(){
     const id = UUID.v4();
-    const App = React.createClass({
+    const App = createReactClass({
       render: function(){
         return <div>
           <DatePicker id={id} />
@@ -275,7 +276,7 @@ describe("Date Picker", function() {
     const id = UUID.v4();
     let value = null;
     let formattedValue = null;
-    const App = React.createClass({
+    const App = createReactClass({
       handleChange: function(newValue, newFormattedValue){
         value = newValue;
         formattedValue = newFormattedValue;
@@ -305,7 +306,7 @@ describe("Date Picker", function() {
     const id = UUID.v4();
     var results = {};
     var value = `${new Date().toISOString().slice(0,10)}T12:00:00.000Z`;
-    const App = React.createClass({
+    const App = createReactClass({
       getInitialState: function() {
         return {
           focused: false
@@ -348,7 +349,7 @@ describe("Date Picker", function() {
   }));
   it('should trim extra characters.', co.wrap(function *(){
     const id = UUID.v4();
-    const App = React.createClass({
+    const App = createReactClass({
       render: function(){
         return <div>
           <DatePicker id={id} />
@@ -366,7 +367,7 @@ describe("Date Picker", function() {
   }));
   it("should automatically insert slashes.", co.wrap(function *(){
     const id = UUID.v4();
-    const App = React.createClass({
+    const App = createReactClass({
       render: function(){
         return <div>
           <DatePicker id={id} />
@@ -389,7 +390,7 @@ describe("Date Picker", function() {
   }));
   it("should automatically insert in YYYY/MM/DD format.", co.wrap(function *(){
     const id = UUID.v4();
-    const App = React.createClass({
+    const App = createReactClass({
       render: function(){
         return <div>
           <DatePicker id={id} dateFormat="YYYY/MM/DD" />
@@ -418,7 +419,7 @@ describe("Date Picker", function() {
     const formattedValues = {};
     const getValues = {};
     const getFormattedValues = {};
-    const App = React.createClass({
+    const App = createReactClass({
       getInitialState: function(){
         return {
           value: null
@@ -514,7 +515,7 @@ describe("Date Picker", function() {
   }));
   it("week should start on Monday.", co.wrap(function *(){
     const id = UUID.v4();
-    const App = React.createClass({
+    const App = createReactClass({
       render: function(){
         return <div>
           <DatePicker id={id} weekStartsOn={1} />
@@ -531,7 +532,7 @@ describe("Date Picker", function() {
   }));
   it("should allow placing the popover calendar in a container specified in the props.", co.wrap(function *(){
     const id = UUID.v4();
-    const App = React.createClass({
+    const App = createReactClass({
       render: function(){
         return <div>
           <DatePicker id={id} calendarContainer={calendarContainer} />
@@ -549,7 +550,7 @@ describe("Date Picker", function() {
   it("should have no focus with autoFocus false.", co.wrap(function *(){
     const id = UUID.v4();
     const value = new Date().toISOString();
-    const App = React.createClass({
+    const App = createReactClass({
       render: function(){
         return <div>
           <DatePicker id={id} value={value} autoFocus={false}/>
@@ -566,7 +567,7 @@ describe("Date Picker", function() {
   it("should have focus with autoFocus true.", co.wrap(function *(){
     const id = UUID.v4();
     const value = new Date().toISOString();
-    const App = React.createClass({
+    const App = createReactClass({
       render: function(){
         return <div>
           <DatePicker id={id} value={value} autoFocus={true}/>
@@ -583,7 +584,7 @@ describe("Date Picker", function() {
   it("should disable the input.", co.wrap(function *(){
     const id = UUID.v4();
     const value = new Date().toISOString();
-    const App = React.createClass({
+    const App = createReactClass({
       render: function(){
         return <div>
           <DatePicker id={id} value={value} disabled={true}/>
@@ -602,7 +603,7 @@ describe("Date Picker", function() {
     const id = UUID.v4();
     let value = new Date().toISOString();
     let originalValue = value;
-    const App = React.createClass({
+    const App = createReactClass({
       handleChange: function(newValue){
         value = newValue;
       },
@@ -626,7 +627,7 @@ describe("Date Picker", function() {
     const id = UUID.v4();
     let value = null;
     let formattedValue = null;
-    const App = React.createClass({
+    const App = createReactClass({
       handleChange: function(newValue, newFormattedValue){
         value = newValue;
         formattedValue = newFormattedValue;
@@ -675,7 +676,7 @@ describe("Date Picker", function() {
     const id = UUID.v4();
     let value = null;
     let formattedValue = null;
-    const App = React.createClass({
+    const App = createReactClass({
       handleChange: function(newValue, newFormattedValue){
         value = newValue;
         formattedValue = newFormattedValue;
@@ -725,7 +726,7 @@ describe("Date Picker", function() {
     const defaultValue = `${new Date().toISOString().slice(0,10)}T12:00:00.000Z`;
     let value = null;
     let formattedValue = null;
-    const App = React.createClass({
+    const App = createReactClass({
       handleChange: function(newValue, newFormattedValue){
         value = newValue;
         formattedValue = newFormattedValue;
@@ -749,7 +750,7 @@ describe("Date Picker", function() {
   }));
   it("should error if value and default value are both set.", co.wrap(function *(){
     const value = new Date().toISOString();
-    const App = React.createClass({
+    const App = createReactClass({
       render: function(){
         return <div>
           <DatePicker value={value} defaultValue={value} />
@@ -768,7 +769,7 @@ describe("Date Picker", function() {
   }));
   it('should render with today button element', co.wrap(function *(){
     const id = UUID.v4();
-    const App = React.createClass({
+    const App = createReactClass({
       render: function(){
         return <div>
           <DatePicker
@@ -790,7 +791,7 @@ describe("Date Picker", function() {
   }));
   it('should render a custom button element', co.wrap(function *(){
     const id = UUID.v4();
-    const App = React.createClass({
+    const App = createReactClass({
       render: function(){
         return <div>
           <DatePicker
@@ -810,7 +811,7 @@ describe("Date Picker", function() {
   it("should set the FormControl className.", co.wrap(function *(){
     const id = UUID.v4();
     const className = `_${UUID.v4()}`;
-    const App = React.createClass({
+    const App = createReactClass({
       render: function(){
         return <div>
           <DatePicker id={id} className={className} />
@@ -826,7 +827,7 @@ describe("Date Picker", function() {
   }));
   it("should set the FormControl style.", co.wrap(function *(){
     const backgroundColor = `rgb(${Math.round(Math.random() * 255, 0)}, ${Math.round(Math.random() * 255, 0)}, ${Math.round(Math.random() * 255, 0)})`;
-    const App = React.createClass({
+    const App = createReactClass({
       render: function(){
         return <div>
           <DatePicker style={{backgroundColor: backgroundColor}}/>
@@ -846,7 +847,7 @@ describe("Date Picker", function() {
     const minDate = "2016-09-11T00:00:00.000Z";
     const maxDate = "2016-09-17T00:00:00.000Z";
     const justRightValue = "2016-09-11T12:00:00.000Z"
-    const App = React.createClass({
+    const App = createReactClass({
       getInitialState: function(){
         return {
           value: originalValue
@@ -882,7 +883,7 @@ describe("Date Picker", function() {
   it("should show next and prev buttons if min and max dates are not set.", co.wrap(function *(){
     const id = UUID.v4();
     const displayDate = "2017-07-21T12:00:00.000Z"
-    const App = React.createClass({
+    const App = createReactClass({
       getInitialState: function(){
         return {
           value: displayDate
@@ -913,7 +914,7 @@ describe("Date Picker", function() {
     const displayDate = "2017-07-21T12:00:00.000Z"
     const minDate = "2017-01-01T12:00:00.000Z";
     const maxDate = "2017-12-31T12:00:00.000Z";
-    const App = React.createClass({
+    const App = createReactClass({
       getInitialState: function(){
         return {
           value: displayDate
@@ -944,7 +945,7 @@ describe("Date Picker", function() {
     const displayDate = "2017-01-15T12:00:00.000Z"
     const minDate = "2017-01-01T12:00:00.000Z";
     const maxDate = "2017-12-31T12:00:00.000Z";
-    const App = React.createClass({
+    const App = createReactClass({
       getInitialState: function(){
         return {
           value: displayDate
@@ -975,7 +976,7 @@ describe("Date Picker", function() {
     const displayDate = "2017-12-15T12:00:00.000Z"
     const minDate = "2017-01-01T12:00:00.000Z";
     const maxDate = "2017-12-31T12:00:00.000Z";
-    const App = React.createClass({
+    const App = createReactClass({
       getInitialState: function(){
         return {
           value: displayDate
@@ -1004,7 +1005,7 @@ describe("Date Picker", function() {
   it("should allow for rounded corners.", co.wrap(function *(){
     const withoutRoundedCorners = "_" + UUID.v4();
     const withRoundedCorners = "_" + UUID.v4();
-    const App = React.createClass({
+    const App = createReactClass({
       render: function(){
         return <div>
           <DatePicker id={withoutRoundedCorners} />
@@ -1029,7 +1030,7 @@ describe("Date Picker", function() {
   }));
   it("week should start on Thursday.", co.wrap(function *(){
     const id = UUID.v4();
-    const App = React.createClass({
+    const App = createReactClass({
       render: function(){
         return <div>
           <DatePicker id={id} weekStartsOn={4} />
@@ -1046,7 +1047,7 @@ describe("Date Picker", function() {
   }));
   it("week should start on Saturday.", co.wrap(function *(){
     const id = UUID.v4();
-    const App = React.createClass({
+    const App = createReactClass({
       render: function(){
         return <div>
           <DatePicker id={id} weekStartsOn={6} />
@@ -1063,7 +1064,7 @@ describe("Date Picker", function() {
   }));
   it("should allow for a string to determine calendar placement", co.wrap(function *(){
     const id = UUID.v4();
-    const App = React.createClass({
+    const App = createReactClass({
       render: function(){
         return <div>
           <DatePicker id={id} calendarPlacement="right" />
@@ -1081,7 +1082,7 @@ describe("Date Picker", function() {
   }));
   it("should allow for a function to determine calendar placement", co.wrap(function *(){
     const id = UUID.v4();
-    const App = React.createClass({
+    const App = createReactClass({
       handlePlacement(){
         return "top";
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1516,6 +1516,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.2:
     create-hash "^1.1.0"
     inherits "^2.0.1"
 
+create-react-class@^15.5.2:
+  version "15.5.2"
+  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.5.2.tgz#6a8758348df660b88326a0e764d569f274aad681"
+  dependencies:
+    fbjs "^0.8.9"
+    object-assign "^4.1.1"
+
 cryptiles@2.x.x:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
@@ -2216,16 +2223,16 @@ faye-websocket@~0.11.0:
   dependencies:
     websocket-driver ">=0.5.1"
 
-fbjs@^0.8.1, fbjs@^0.8.4:
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.5.tgz#f69ba8a876096cb1b9bffe4d7c1e71c19d39d008"
+fbjs@^0.8.9:
+  version "0.8.12"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
   dependencies:
     core-js "^1.0.0"
-    immutable "^3.7.6"
     isomorphic-fetch "^2.1.1"
     loose-envify "^1.0.0"
     object-assign "^4.1.0"
     promise "^7.1.1"
+    setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
 figures@^1.3.5:
@@ -2697,10 +2704,6 @@ ieee754@^1.1.4:
 ignore@^3.2.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.2.6.tgz#26e8da0644be0bb4cb39516f6c79f0e0f4ffe48c"
-
-immutable@^3.7.6:
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.1.tgz#200807f11ab0f72710ea485542de088075f68cd2"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -3637,9 +3640,13 @@ oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@4.1.0, object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@4.1.0, object-assign@^4.0.1:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.0.tgz#7a3b3d0e98063d43f4c03f2e8ae6cd51a86883a0"
+
+object-assign@^4.1.0, object-assign@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
 object-component@0.0.3:
   version "0.0.3"
@@ -3924,6 +3931,12 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@~15.5.7:
+  version "15.5.8"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
+  dependencies:
+    fbjs "^0.8.9"
+
 proxy-addr@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-1.1.2.tgz#b4cc5f22610d9535824c123aef9d3cf73c40ba37"
@@ -4022,41 +4035,37 @@ rc@~1.1.6:
     minimist "^1.2.0"
     strip-json-comments "~1.0.4"
 
-react-addons-test-utils@^15.4.2:
-  version "15.4.2"
-  resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.4.2.tgz#93bcaa718fcae7360d42e8fb1c09756cc36302a2"
-  dependencies:
-    fbjs "^0.8.4"
-    object-assign "^4.1.0"
-
-react-bootstrap@^0.30.8:
-  version "0.30.8"
-  resolved "https://registry.yarnpkg.com/react-bootstrap/-/react-bootstrap-0.30.8.tgz#4ceca8e138ce2351228c4a58d59db00c003ca9c0"
+react-bootstrap@^0.31.0:
+  version "0.31.0"
+  resolved "https://registry.yarnpkg.com/react-bootstrap/-/react-bootstrap-0.31.0.tgz#bbca804c0404d9c640102b2b656ae4cd5bea35c8"
   dependencies:
     babel-runtime "^6.11.6"
     classnames "^2.2.5"
     dom-helpers "^3.2.0"
     invariant "^2.2.1"
     keycode "^2.1.2"
-    react-overlays "^0.6.12"
+    prop-types "^15.5.6"
+    react-overlays "^0.7.0"
     react-prop-types "^0.4.0"
-    uncontrollable "^4.0.1"
+    uncontrollable "^4.1.0"
     warning "^3.0.0"
 
-react-dom@^15.4.2:
-  version "15.4.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.4.2.tgz#015363f05b0a1fd52ae9efdd3a0060d90695208f"
+react-dom@^15.5.4:
+  version "15.5.4"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.5.4.tgz#ba0c28786fd52ed7e4f2135fe0288d462aef93da"
   dependencies:
-    fbjs "^0.8.1"
+    fbjs "^0.8.9"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
+    prop-types "~15.5.7"
 
-react-overlays@^0.6.12:
-  version "0.6.12"
-  resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-0.6.12.tgz#a079c750cc429d7db4c7474a95b4b54033e255c3"
+react-overlays@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-0.7.0.tgz#531898ff566c7e5c7226ead2863b8cf9fbb5a981"
   dependencies:
     classnames "^2.2.5"
     dom-helpers "^3.2.0"
+    prop-types "^15.5.8"
     react-prop-types "^0.4.0"
     warning "^3.0.0"
 
@@ -4066,13 +4075,14 @@ react-prop-types@^0.4.0:
   dependencies:
     warning "^3.0.0"
 
-react@^15.4.2:
-  version "15.4.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.4.2.tgz#41f7991b26185392ba9bae96c8889e7e018397ef"
+react@^15.5.4:
+  version "15.5.4"
+  resolved "https://registry.yarnpkg.com/react/-/react-15.5.4.tgz#fa83eb01506ab237cdc1c8c3b1cea8de012bf047"
   dependencies:
-    fbjs "^0.8.4"
+    fbjs "^0.8.9"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
+    prop-types "^15.5.7"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -4454,7 +4464,7 @@ set-immediate-shim@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
 
-"setimmediate@>= 1.0.1 < 2", "setimmediate@>= 1.0.2 < 2", setimmediate@^1.0.4:
+"setimmediate@>= 1.0.1 < 2", "setimmediate@>= 1.0.2 < 2", setimmediate@^1.0.4, setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
 
@@ -4944,9 +4954,9 @@ ultron@1.0.x:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.0.2.tgz#ace116ab557cd197386a4e88f4685378c8b2e4fa"
 
-uncontrollable@^4.0.1:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-4.0.3.tgz#06ec76cb9e02914756085d9cea0354fc746b09b4"
+uncontrollable@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-4.1.0.tgz#e0358291252e1865222d90939b19f2f49f81c1a9"
   dependencies:
     invariant "^2.1.0"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* Updates dependencies
* React.PropTypes -> PropTypes
* React.createClass -> createReactClass

## Motivation and Context
React 15.5.0 introduced deprecation warnings for PropTypes, createClass, and react-addons: https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html

Fixes #114 

## How Has This Been Tested?
Ran npm test on my machine, all tests passed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
