### PR TITLE
Show week numbers

### DIFF
--- a/example/app.jsx
+++ b/example/app.jsx
@@ -222,6 +222,20 @@ const App = createReactClass({
         </Col>
       </Row>
       <Row>
+        <Col xs={6}>
+          <h2>Show Week Numbers</h2>
+        </Col>
+      </Row>
+      <Row>
+        <Col xs={6}>
+          <FormGroup controlId="show_weeks">
+            <ControlLabel>Show Weeks</ControlLabel>
+            <DatePicker onChange={this.handleChange} placeholder="Placeholder" value={this.state.date} id="show_dates_example" showWeeks={true} />
+            <HelpBlock>Help</HelpBlock>
+          </FormGroup>
+        </Col>
+      </Row>
+      <Row>
         <Col xs={12}>
           <h2>Custom</h2>
         </Col>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -189,7 +189,7 @@ const Calendar = createReactClass({
         const weekNum = this.getWeekNumber(new Date(year, month,  day - 1, 12, 0, 0, 0));
         week.unshift(<td
             key={7}
-            style={{padding: this.props.cellPadding, fontSize: '0.8em', color: "darkgrey"}}
+            style={{padding: this.props.cellPadding, fontSize: '0.8em', color: 'darkgrey'}}
             className="text-muted"
         >
           {weekNum}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -80,17 +80,18 @@ const Calendar = createReactClass({
   displayName: 'DatePickerCalendar',
 
   propTypes: {
-    selectedDate: PropTypes.object,
-    displayDate: PropTypes.object.isRequired,
-    minDate: PropTypes.string,
-    maxDate: PropTypes.string,
-    onChange: PropTypes.func.isRequired,
-    dayLabels: PropTypes.array.isRequired,
-    cellPadding: PropTypes.string.isRequired,
-    weekStartsOn: PropTypes.number,
-    showTodayButton: PropTypes.bool,
-    todayButtonLabel: PropTypes.string,
-    roundedCorners: PropTypes.bool
+    selectedDate: React.PropTypes.object,
+    displayDate: React.PropTypes.object.isRequired,
+    minDate: React.PropTypes.string,
+    maxDate: React.PropTypes.string,
+    onChange: React.PropTypes.func.isRequired,
+    dayLabels: React.PropTypes.array.isRequired,
+    cellPadding: React.PropTypes.string.isRequired,
+    weekStartsOn: React.PropTypes.number,
+    showTodayButton: React.PropTypes.bool,
+    todayButtonLabel: React.PropTypes.string,
+    roundedCorners: React.PropTypes.bool,
+    showWeeks: React.PropTypes.bool
   },
 
   handleClick(day) {
@@ -112,6 +113,18 @@ const Calendar = createReactClass({
     return date;
   },
 
+  getWeekNumber(date){
+    const target  = new Date(date.valueOf());
+    const dayNr   = (date.getDay() + 6) % 7;
+    target.setDate(target.getDate() - dayNr + 3);
+    const firstThursday = target.valueOf();
+    target.setMonth(0, 1);
+    if (target.getDay() !== 4) {
+      target.setMonth(0, 1 + ((4 - target.getDay()) + 7) % 7);
+    }
+    return 1 + Math.ceil((firstThursday - target) / 604800000);
+  },
+
   render() {
     const currentDate = this.setTimeToNoon(new Date());
     const selectedDate = this.props.selectedDate ? this.setTimeToNoon(new Date(this.props.selectedDate)) : null;
@@ -125,6 +138,7 @@ const Calendar = createReactClass({
       : this.props.weekStartsOn === 1
         ? (firstDay.getDay() === 0 ? 6 : firstDay.getDay() - 1)
         : firstDay.getDay();
+    const showWeeks = this.props.showWeeks;
 
     let monthLength = daysInMonth[month];
     if (month == 1) {
@@ -151,25 +165,36 @@ const Calendar = createReactClass({
             >
               {day}
             </td>);
-          } else {
-            if (Date.parse(date) === Date.parse(selectedDate)) {
-              className = 'bg-primary';
-            } else if (Date.parse(date) === Date.parse(currentDate)) {
-              className = 'text-primary';
-            }
-            week.push(<td
-              key={j}
-              onClick={this.handleClick.bind(this, day)}
-              style={{ cursor: 'pointer', padding: this.props.cellPadding, borderRadius: this.props.roundedCorners ? 5 : 0 }}
-              className={className}
-            >
-              {day}
-            </td>);
+          } else if (Date.parse(date) === Date.parse(selectedDate)) {
+            className = 'bg-primary';
+          } else if (Date.parse(date) === Date.parse(currentDate)) {
+            className = 'text-primary';
           }
+          week.push(<td
+            key={j}
+            onClick={this.handleClick.bind(this, day)}
+            style={{ cursor: 'pointer', padding: this.props.cellPadding, borderRadius: this.props.roundedCorners ? 5 : 0 }}
+            className={className}
+          >
+            {day}
+          </td>);
           day++;
         } else {
           week.push(<td key={j} />);
         }
+      }
+
+
+      if (showWeeks){
+        const weekNum = this.getWeekNumber(new Date(year, month,  day - 1, 12, 0, 0, 0));
+        week.unshift(<td
+            key={7}
+            style={{padding: this.props.cellPadding, fontSize: '0.8em', color: "darkgrey"}}
+            className="text-muted"
+        >
+          {weekNum}
+        </td>);
+
       }
 
       weeks.push(<tr key={i}>{week}</tr>);
@@ -178,9 +203,16 @@ const Calendar = createReactClass({
       }
     }
 
+    const weekColumn = showWeeks ?
+        <td
+        className="text-muted current-week"
+        style={{padding: this.props.cellPadding}} /> :
+        null;
+
     return <table className="text-center">
       <thead>
         <tr>
+          {weekColumn}
           {this.props.dayLabels.map((label, index)=>{
             return <td
               key={index}
@@ -267,9 +299,11 @@ export default createReactClass({
     instanceCount: PropTypes.number,
     customControl: PropTypes.object,
     roundedCorners: PropTypes.bool,
+    showWeeks: PropTypes.bool,
     children: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.node),
       PropTypes.node
+
     ])
   },
 
@@ -293,6 +327,7 @@ export default createReactClass({
       showTodayButton: false,
       todayButtonLabel: 'Today',
       autoComplete: 'on',
+      showWeeks: false,
       instanceCount: instanceCount++,
       style: {
         width: '100%'
@@ -659,6 +694,7 @@ export default createReactClass({
             minDate={this.props.minDate}
             maxDate={this.props.maxDate}
             roundedCorners={this.props.roundedCorners}
+            showWeeks={this.props.showWeeks}
            />
         </Popover>
       </Overlay>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The current bootstrap date picker gives the ability to show week numbers in the calendar.  This is quite a useful feature for countries that are used to using week numbers with regards to dates.  This PR adds a the ability for the date picker to show week numbers.

## Motivation and Context
As mentioned above, many countries especially in Scandinavia address weeks and or dates by week numbers and this is often a very handy UI component to have when selecting dates from a date picker.  Adding this as an optional functionality further enriches the react date picker library to be able to suit these needs and address the problem of not having the calendar weeks. 

## How Has This Been Tested?
I have run this through the appropriate tests and seem to get a single fail point on an assertion that as far as I can tell has nothing to do with the week number edits.  However if someone else sees that my changes have indeed created this error I will fix it.  I have also tested manually the week numbers to make sure that edge cases such as leap years, and years (such as 2010) have proper week numbers addressed to the weeks.  I used the Wikipedia week number ISO standard table as a reference. 

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/20356461/27170012-a5f8be8e-51ac-11e7-8800-51b4021b1df6.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

I have updated the example page but not the documentation.  This can be done if necessary.  I left the added and current tests empty as I get the same single error when I run my tests before any of my changes.  So although there is one error present it is present before my changes.  

Let me know if there are any changes and Ill be happy to address them!  We planning on using this in production for a soon to be release and I will be prompt with my responses! 
Cheers
