### PR TITLE
Propagate html5 validation properties

### DIFF
--- a/example/app.jsx
+++ b/example/app.jsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import Grid from 'react-bootstrap/lib/Grid';
 import Row from 'react-bootstrap/lib/Row';
 import Col from 'react-bootstrap/lib/Col';
-import { Navbar, Button } from 'react-bootstrap';
+import { Form, Navbar, Button } from 'react-bootstrap';
 import Nav from 'react-bootstrap/lib/Nav';
 import NavItem from 'react-bootstrap/lib/NavItem';
 import DatePicker from '../src/index.jsx';
@@ -25,7 +25,8 @@ const App = createReactClass({
       previousDate: null,
       minDate: null,
       maxDate: null,
-      focused: false
+      focused: false,
+      invalid: false
     };
   },
   handleChange(value) {
@@ -58,6 +59,24 @@ const App = createReactClass({
       default:
         return 'bottom';
     }
+  },
+  handleValidationCheck(e) {
+    e.preventDefault();
+    this.setState(() => ({
+      invalid: false
+    }));
+  },
+  handleInvalidDate(e) {
+    e.preventDefault();
+    this.setState(() => ({
+      invalid: true
+    }));
+  },
+  handleResetValidation(e) {
+    e.preventDefault();
+    this.setState(() => ({
+      invalid: false
+    }));
   },
   render() {
     const LabelISOString = new Date().toISOString();
@@ -234,6 +253,42 @@ const App = createReactClass({
             <HelpBlock>Help</HelpBlock>
           </FormGroup>
         </Col>
+      </Row>
+      <Row>
+        <Col xs={6}>
+          <h2>Validation</h2>
+        </Col>
+      </Row>
+      <Row>
+        <Form onSubmit={this.handleValidationCheck}>
+          <Col xs={6}>
+              <FormGroup controlId="custom_validation_example_default" validationState={this.state.invalid ? 'error' : null}>
+                <ControlLabel>Default</ControlLabel>
+                <DatePicker
+                  onChange={this.handleChange}
+                  placeholder="Placeholder"
+                  required
+                />
+            </FormGroup>
+          </Col>
+          <Col xs={6}>
+              <FormGroup controlId="custom_validation_example_oninvalid" validationState={this.state.invalid ? 'error' : null}>
+                <ControlLabel>onInvalid override</ControlLabel>
+                <DatePicker
+                  onChange={this.handleChange}
+                  placeholder="Placeholder"
+                  onInvalid={this.handleInvalidDate}
+                  required
+                />
+                {this.state.invalid
+                  && <HelpBlock>You must pick a date.</HelpBlock>}
+            </FormGroup>
+          </Col>
+          <Col xs={6}>
+            <Button type="submit">Validate</Button>
+            <Button type="button" onClick={this.handleResetValidation}>Reset</Button>
+          </Col>
+        </Form>
       </Row>
       <Row>
         <Col xs={12}>

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,21 +32,45 @@ var _Popover = require('react-bootstrap/lib/Popover');
 
 var _Popover2 = _interopRequireDefault(_Popover);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 var instanceCount = 0; // See http://jszen.blogspot.com/2007/03/how-to-build-simple-calendar-with.html for calendar logic.
 
-var CalendarHeader = _react2.default.createClass({
+var CalendarHeader = (0, _createReactClass2.default)({
   displayName: 'DatePickerHeader',
 
   propTypes: {
-    displayDate: _react2.default.PropTypes.object.isRequired,
-    onChange: _react2.default.PropTypes.func.isRequired,
-    monthLabels: _react2.default.PropTypes.array.isRequired,
-    previousButtonElement: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.string, _react2.default.PropTypes.object]).isRequired,
-    nextButtonElement: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.string, _react2.default.PropTypes.object]).isRequired
+    displayDate: _propTypes2.default.object.isRequired,
+    minDate: _propTypes2.default.string,
+    maxDate: _propTypes2.default.string,
+    onChange: _propTypes2.default.func.isRequired,
+    monthLabels: _propTypes2.default.array.isRequired,
+    previousButtonElement: _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.object]).isRequired,
+    nextButtonElement: _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.object]).isRequired
   },
 
+  displayingMinMonth: function displayingMinMonth() {
+    if (!this.props.minDate) return false;
+
+    var displayDate = new Date(this.props.displayDate);
+    var minDate = new Date(this.props.minDate);
+    return minDate.getFullYear() == displayDate.getFullYear() && minDate.getMonth() == displayDate.getMonth();
+  },
+  displayingMaxMonth: function displayingMaxMonth() {
+    if (!this.props.maxDate) return false;
+
+    var displayDate = new Date(this.props.displayDate);
+    var maxDate = new Date(this.props.maxDate);
+    return maxDate.getFullYear() == displayDate.getFullYear() && maxDate.getMonth() == displayDate.getMonth();
+  },
   handleClickPrevious: function handleClickPrevious() {
     var newDisplayDate = new Date(this.props.displayDate);
     newDisplayDate.setDate(1);
@@ -65,8 +89,8 @@ var CalendarHeader = _react2.default.createClass({
       { className: 'text-center' },
       _react2.default.createElement(
         'div',
-        { className: 'text-muted pull-left', onClick: this.handleClickPrevious, style: { cursor: 'pointer' } },
-        this.props.previousButtonElement
+        { className: 'text-muted pull-left datepicker-previous-wrapper', onClick: this.handleClickPrevious, style: { cursor: 'pointer' } },
+        this.displayingMinMonth() ? null : this.props.previousButtonElement
       ),
       _react2.default.createElement(
         'span',
@@ -77,8 +101,8 @@ var CalendarHeader = _react2.default.createClass({
       ),
       _react2.default.createElement(
         'div',
-        { className: 'text-muted pull-right', onClick: this.handleClickNext, style: { cursor: 'pointer' } },
-        this.props.nextButtonElement
+        { className: 'text-muted pull-right datepicker-next-wrapper', onClick: this.handleClickNext, style: { cursor: 'pointer' } },
+        this.displayingMaxMonth() ? null : this.props.nextButtonElement
       )
     );
   }
@@ -86,7 +110,7 @@ var CalendarHeader = _react2.default.createClass({
 
 var daysInMonth = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 
-var Calendar = _react2.default.createClass({
+var Calendar = (0, _createReactClass2.default)({
   displayName: 'DatePickerCalendar',
 
   propTypes: {
@@ -100,7 +124,8 @@ var Calendar = _react2.default.createClass({
     weekStartsOn: _react2.default.PropTypes.number,
     showTodayButton: _react2.default.PropTypes.bool,
     todayButtonLabel: _react2.default.PropTypes.string,
-    roundedCorners: _react2.default.PropTypes.bool
+    roundedCorners: _react2.default.PropTypes.bool,
+    showWeeks: _react2.default.PropTypes.bool
   },
 
   handleClick: function handleClick(day) {
@@ -119,6 +144,17 @@ var Calendar = _react2.default.createClass({
     date.setMilliseconds(0);
     return date;
   },
+  getWeekNumber: function getWeekNumber(date) {
+    var target = new Date(date.valueOf());
+    var dayNr = (date.getDay() + 6) % 7;
+    target.setDate(target.getDate() - dayNr + 3);
+    var firstThursday = target.valueOf();
+    target.setMonth(0, 1);
+    if (target.getDay() !== 4) {
+      target.setMonth(0, 1 + (4 - target.getDay() + 7) % 7);
+    }
+    return 1 + Math.ceil((firstThursday - target) / 604800000);
+  },
   render: function render() {
     var _this = this;
 
@@ -130,6 +166,7 @@ var Calendar = _react2.default.createClass({
     var month = this.props.displayDate.getMonth();
     var firstDay = new Date(year, month, 1);
     var startingDay = this.props.weekStartsOn > 1 ? firstDay.getDay() - this.props.weekStartsOn + 7 : this.props.weekStartsOn === 1 ? firstDay.getDay() === 0 ? 6 : firstDay.getDay() - 1 : firstDay.getDay();
+    var showWeeks = this.props.showWeeks;
 
     var monthLength = daysInMonth[month];
     if (month == 1) {
@@ -158,27 +195,38 @@ var Calendar = _react2.default.createClass({
               },
               day
             ));
-          } else {
-            if (Date.parse(date) === Date.parse(selectedDate)) {
-              className = 'bg-primary';
-            } else if (Date.parse(date) === Date.parse(currentDate)) {
-              className = 'text-primary';
-            }
-            week.push(_react2.default.createElement(
-              'td',
-              {
-                key: j,
-                onClick: this.handleClick.bind(this, day),
-                style: { cursor: 'pointer', padding: this.props.cellPadding, borderRadius: this.props.roundedCorners ? 5 : 0 },
-                className: className
-              },
-              day
-            ));
+          } else if (Date.parse(date) === Date.parse(selectedDate)) {
+            className = 'bg-primary';
+          } else if (Date.parse(date) === Date.parse(currentDate)) {
+            className = 'text-primary';
           }
+          week.push(_react2.default.createElement(
+            'td',
+            {
+              key: j,
+              onClick: this.handleClick.bind(this, day),
+              style: { cursor: 'pointer', padding: this.props.cellPadding, borderRadius: this.props.roundedCorners ? 5 : 0 },
+              className: className
+            },
+            day
+          ));
           day++;
         } else {
           week.push(_react2.default.createElement('td', { key: j }));
         }
+      }
+
+      if (showWeeks) {
+        var weekNum = this.getWeekNumber(new Date(year, month, day - 1, 12, 0, 0, 0));
+        week.unshift(_react2.default.createElement(
+          'td',
+          {
+            key: 7,
+            style: { padding: this.props.cellPadding, fontSize: '0.8em', color: 'darkgrey' },
+            className: 'text-muted'
+          },
+          weekNum
+        ));
       }
 
       weeks.push(_react2.default.createElement(
@@ -191,6 +239,10 @@ var Calendar = _react2.default.createClass({
       }
     }
 
+    var weekColumn = showWeeks ? _react2.default.createElement('td', {
+      className: 'text-muted current-week',
+      style: { padding: this.props.cellPadding } }) : null;
+
     return _react2.default.createElement(
       'table',
       { className: 'text-center' },
@@ -200,6 +252,7 @@ var Calendar = _react2.default.createClass({
         _react2.default.createElement(
           'tr',
           null,
+          weekColumn,
           this.props.dayLabels.map(function (label, index) {
             return _react2.default.createElement(
               'td',
@@ -246,51 +299,54 @@ var Calendar = _react2.default.createClass({
   }
 });
 
-exports.default = _react2.default.createClass({
+exports.default = (0, _createReactClass2.default)({
   displayName: 'DatePicker',
 
   propTypes: {
-    defaultValue: _react2.default.PropTypes.string,
-    value: _react2.default.PropTypes.string,
-    required: _react2.default.PropTypes.bool,
-    className: _react2.default.PropTypes.string,
-    style: _react2.default.PropTypes.object,
-    minDate: _react2.default.PropTypes.string,
-    maxDate: _react2.default.PropTypes.string,
-    cellPadding: _react2.default.PropTypes.string,
-    autoComplete: _react2.default.PropTypes.string,
-    placeholder: _react2.default.PropTypes.string,
-    dayLabels: _react2.default.PropTypes.array,
-    monthLabels: _react2.default.PropTypes.array,
-    onChange: _react2.default.PropTypes.func,
-    onClear: _react2.default.PropTypes.func,
-    onBlur: _react2.default.PropTypes.func,
-    onFocus: _react2.default.PropTypes.func,
-    autoFocus: _react2.default.PropTypes.bool,
-    disabled: _react2.default.PropTypes.bool,
+    defaultValue: _propTypes2.default.string,
+    value: _propTypes2.default.string,
+    required: _propTypes2.default.bool,
+    className: _propTypes2.default.string,
+    style: _propTypes2.default.object,
+    minDate: _propTypes2.default.string,
+    maxDate: _propTypes2.default.string,
+    cellPadding: _propTypes2.default.string,
+    autoComplete: _propTypes2.default.string,
+    placeholder: _propTypes2.default.string,
+    dayLabels: _propTypes2.default.array,
+    monthLabels: _propTypes2.default.array,
+    onChange: _propTypes2.default.func,
+    onClear: _propTypes2.default.func,
+    onBlur: _propTypes2.default.func,
+    onFocus: _propTypes2.default.func,
+    autoFocus: _propTypes2.default.bool,
+    disabled: _propTypes2.default.bool,
     weekStartsOnMonday: function weekStartsOnMonday(props, propName, componentName) {
       if (props[propName]) {
         return new Error('Prop \'' + propName + '\' supplied to \'' + componentName + '\' is obsolete. Use \'weekStartsOn\' instead.');
       }
     },
-    weekStartsOn: _react2.default.PropTypes.number,
-    clearButtonElement: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.string, _react2.default.PropTypes.object]),
-    showClearButton: _react2.default.PropTypes.bool,
-    previousButtonElement: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.string, _react2.default.PropTypes.object]),
-    nextButtonElement: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.string, _react2.default.PropTypes.object]),
-    calendarPlacement: _react2.default.PropTypes.string,
-    dateFormat: _react2.default.PropTypes.string, // 'MM/DD/YYYY', 'DD/MM/YYYY', 'YYYY/MM/DD', 'DD-MM-YYYY'
-    bsClass: _react2.default.PropTypes.string,
-    bsSize: _react2.default.PropTypes.string,
-    calendarContainer: _react2.default.PropTypes.object,
-    id: _react2.default.PropTypes.string,
-    name: _react2.default.PropTypes.string,
-    showTodayButton: _react2.default.PropTypes.bool,
-    todayButtonLabel: _react2.default.PropTypes.string,
-    instanceCount: _react2.default.PropTypes.number,
-    customControl: _react2.default.PropTypes.object,
-    roundedCorners: _react2.default.PropTypes.bool,
-    children: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.arrayOf(_react2.default.PropTypes.node), _react2.default.PropTypes.node])
+    weekStartsOn: _propTypes2.default.number,
+    clearButtonElement: _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.object]),
+    showClearButton: _propTypes2.default.bool,
+    previousButtonElement: _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.object]),
+    nextButtonElement: _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.object]),
+    calendarPlacement: _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.func]),
+    dateFormat: _propTypes2.default.string, // 'MM/DD/YYYY', 'DD/MM/YYYY', 'YYYY/MM/DD', 'DD-MM-YYYY'
+    bsClass: _propTypes2.default.string,
+    bsSize: _propTypes2.default.string,
+    calendarContainer: _propTypes2.default.object,
+    id: _propTypes2.default.string,
+    name: _propTypes2.default.string,
+    showTodayButton: _propTypes2.default.bool,
+    todayButtonLabel: _propTypes2.default.string,
+    instanceCount: _propTypes2.default.number,
+    customControl: _propTypes2.default.object,
+    roundedCorners: _propTypes2.default.bool,
+    showWeeks: _propTypes2.default.bool,
+    children: _propTypes2.default.oneOfType([_propTypes2.default.arrayOf(_propTypes2.default.node), _propTypes2.default.node]),
+    onInvalid: _propTypes2.default.func,
+    noValidate: _propTypes2.default.bool
   },
 
   getDefaultProps: function getDefaultProps() {
@@ -311,11 +367,13 @@ exports.default = _react2.default.createClass({
       showTodayButton: false,
       todayButtonLabel: 'Today',
       autoComplete: 'on',
+      showWeeks: false,
       instanceCount: instanceCount++,
       style: {
         width: '100%'
       },
-      roundedCorners: false
+      roundedCorners: false,
+      noValidate: false
     };
   },
   getInitialState: function getInitialState() {
@@ -339,11 +397,21 @@ exports.default = _react2.default.createClass({
   makeDateValues: function makeDateValues(isoString) {
     var displayDate = void 0;
     var selectedDate = isoString ? new Date(isoString.slice(0, 10) + 'T12:00:00.000Z') : null;
+    var minDate = this.props.minDate ? new Date(isoString.slice(0, 10) + 'T12:00:00.000Z') : null;
+    var maxDate = this.props.maxDate ? new Date(isoString.slice(0, 10) + 'T12:00:00.000Z') : null;
+
     var inputValue = isoString ? this.makeInputValueString(selectedDate) : null;
     if (selectedDate) {
       displayDate = new Date(selectedDate);
     } else {
-      displayDate = new Date(new Date().toISOString().slice(0, 10) + 'T12:00:00.000Z');
+      var today = new Date(new Date().toISOString().slice(0, 10) + 'T12:00:00.000Z');
+      if (minDate && Date.parse(minDate) >= Date.parse(today)) {
+        displayDate = minDate;
+      } else if (maxDate && Date.parse(maxDate) <= Date.parse(today)) {
+        displayDate = maxDate;
+      } else {
+        displayDate = today;
+      }
     }
 
     return {
@@ -397,9 +465,12 @@ exports.default = _react2.default.createClass({
       return;
     }
 
+    var placement = this.getCalendarPlacement();
+
     this.setState({
       inputFocused: true,
-      focused: true
+      focused: true,
+      calendarPlacement: placement
     });
 
     if (this.props.onFocus) {
@@ -425,6 +496,15 @@ exports.default = _react2.default.createClass({
   },
   getFormattedValue: function getFormattedValue() {
     return this.state.displayDate ? this.state.inputValue : null;
+  },
+  getCalendarPlacement: function getCalendarPlacement() {
+    var tag = Object.prototype.toString.call(this.props.calendarPlacement);
+    var isFunction = tag === '[object AsyncFunction]' || tag === '[object Function]' || tag === '[object GeneratorFunction]' || tag === '[object Proxy]';
+    if (isFunction) {
+      return this.props.calendarPlacement();
+    } else {
+      return this.props.calendarPlacement;
+    }
   },
   makeInputValueString: function makeInputValueString(date) {
     var month = date.getMonth() + 1;
@@ -475,6 +555,11 @@ exports.default = _react2.default.createClass({
 
     var originalValue = _reactDom2.default.findDOMNode(this.refs.input).value;
     var inputValue = originalValue.replace(/(-|\/\/)/g, this.state.separator).slice(0, 10);
+
+    if (!inputValue) {
+      this.clear();
+      return;
+    }
 
     var month = void 0,
         day = void 0,
@@ -568,6 +653,8 @@ exports.default = _react2.default.createClass({
       previousButtonElement: this.props.previousButtonElement,
       nextButtonElement: this.props.nextButtonElement,
       displayDate: this.state.displayDate,
+      minDate: this.props.minDate,
+      maxDate: this.props.maxDate,
       onChange: this.onChangeMonth,
       monthLabels: this.props.monthLabels,
       dateFormat: this.props.dateFormat });
@@ -584,7 +671,9 @@ exports.default = _react2.default.createClass({
       onChange: this.handleInputChange,
       className: this.props.className,
       style: this.props.style,
-      autoComplete: this.props.autoComplete
+      autoComplete: this.props.autoComplete,
+      onInvalid: this.props.onInvalid,
+      noValidate: this.props.noValidate
     }) : _react2.default.createElement(_FormControl2.default, {
       onKeyDown: this.handleKeyDown,
       value: this.state.inputValue || '',
@@ -599,7 +688,9 @@ exports.default = _react2.default.createClass({
       onFocus: this.handleFocus,
       onBlur: this.handleBlur,
       onChange: this.handleInputChange,
-      autoComplete: this.props.autoComplete
+      autoComplete: this.props.autoComplete,
+      onInvalid: this.props.onInvalid,
+      noValidate: this.props.noValidate
     });
 
     return _react2.default.createElement(
@@ -622,7 +713,7 @@ exports.default = _react2.default.createClass({
           target: function target() {
             return _reactDom2.default.findDOMNode(_this2.refs.input);
           },
-          placement: this.props.calendarPlacement,
+          placement: this.state.calendarPlacement,
           delayHide: 200 },
         _react2.default.createElement(
           _Popover2.default,
@@ -638,7 +729,8 @@ exports.default = _react2.default.createClass({
             todayButtonLabel: this.props.todayButtonLabel,
             minDate: this.props.minDate,
             maxDate: this.props.maxDate,
-            roundedCorners: this.props.roundedCorners
+            roundedCorners: this.props.roundedCorners,
+            showWeeks: this.props.showWeeks
           })
         )
       ),

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -304,7 +304,9 @@ export default createReactClass({
       PropTypes.arrayOf(PropTypes.node),
       PropTypes.node
 
-    ])
+    ]),
+    onInvalid: PropTypes.func,
+    noValidate: PropTypes.bool
   },
 
   getDefaultProps() {
@@ -332,7 +334,8 @@ export default createReactClass({
       style: {
         width: '100%'
       },
-      roundedCorners: false
+      roundedCorners: false,
+      noValidate: false
     };
   },
 
@@ -649,6 +652,8 @@ export default createReactClass({
         className: this.props.className,
         style: this.props.style,
         autoComplete: this.props.autoComplete,
+        onInvalid: this.props.onInvalid,
+        noValidate: this.props.noValidate,
       })
       : <FormControl
           onKeyDown={this.handleKeyDown}
@@ -665,6 +670,8 @@ export default createReactClass({
           onBlur={this.handleBlur}
           onChange={this.handleInputChange}
           autoComplete={this.props.autoComplete}
+          onInvalid={this.props.onInvalid}
+          noValidate={this.props.noValidate}
           />;
 
     return <InputGroup


### PR DESCRIPTION
Pass onInvalid and novalidation to the underlying input to allow disabling the browser default validation behavior, and hooking into the invalid event to provide custom handling.

## Motivation and Context
Sometimes the browser default behaviour when an input in invalid is undesired.

## How Has This Been Tested?
Test suit run, example added to examples page demonstrating use.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
