### PR TITLE
Fixing duplicate key warning when minDate or maxDate

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -128,7 +128,8 @@ var Calendar = (0, _createReactClass2.default)({
     showWeeks: _react2.default.PropTypes.bool
   },
 
-  handleClick: function handleClick(day) {
+  handleClick: function handleClick(e) {
+    var day = e.currentTarget.getAttribute('data-day');
     var newSelectedDate = this.setTimeToNoon(new Date(this.props.displayDate));
     newSelectedDate.setDate(day);
     this.props.onChange(newSelectedDate);
@@ -185,27 +186,26 @@ var Calendar = (0, _createReactClass2.default)({
           var date = new Date(year, month, day, 12, 0, 0, 0).toISOString();
           var beforeMinDate = minDate && Date.parse(date) < Date.parse(minDate);
           var afterMinDate = maxDate && Date.parse(date) > Date.parse(maxDate);
+          var clickHandler = this.handleClick;
+          var style = { cursor: 'pointer', padding: this.props.cellPadding, borderRadius: this.props.roundedCorners ? 5 : 0 };
+
           if (beforeMinDate || afterMinDate) {
-            week.push(_react2.default.createElement(
-              'td',
-              {
-                key: j,
-                style: { padding: this.props.cellPadding },
-                className: 'text-muted'
-              },
-              day
-            ));
+            className = 'text-muted';
+            clickHandler = null;
+            style.cursor = 'default';
           } else if (Date.parse(date) === Date.parse(selectedDate)) {
             className = 'bg-primary';
           } else if (Date.parse(date) === Date.parse(currentDate)) {
             className = 'text-primary';
           }
+
           week.push(_react2.default.createElement(
             'td',
             {
               key: j,
-              onClick: this.handleClick.bind(this, day),
-              style: { cursor: 'pointer', padding: this.props.cellPadding, borderRadius: this.props.roundedCorners ? 5 : 0 },
+              'data-day': day,
+              onClick: clickHandler,
+              style: style,
               className: className
             },
             day

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -94,12 +94,12 @@ const Calendar = createReactClass({
     showWeeks: React.PropTypes.bool
   },
 
-	handleClick(e) {
-		const day = e.currentTarget.getAttribute('data-day');
-		const newSelectedDate = this.setTimeToNoon(new Date(this.props.displayDate));
-		newSelectedDate.setDate(day);
-		this.props.onChange(newSelectedDate);
-	},
+  handleClick(e) {
+    const day = e.currentTarget.getAttribute('data-day');
+    const newSelectedDate = this.setTimeToNoon(new Date(this.props.displayDate));
+    newSelectedDate.setDate(day);
+    this.props.onChange(newSelectedDate);
+  },
 
   handleClickToday() {
     const newSelectedDate = this.setTimeToNoon(new Date());
@@ -158,28 +158,28 @@ const Calendar = createReactClass({
           const date = new Date(year, month, day, 12, 0, 0, 0).toISOString();
           const beforeMinDate = minDate && Date.parse(date) < Date.parse(minDate);
           const afterMinDate = maxDate && Date.parse(date) > Date.parse(maxDate);
-					let clickHandler = this.handleClick;
-					const style = { cursor: 'pointer', padding: this.props.cellPadding, borderRadius: this.props.roundedCorners ? 5 : 0 };
+          let clickHandler = this.handleClick;
+          const style = { cursor: 'pointer', padding: this.props.cellPadding, borderRadius: this.props.roundedCorners ? 5 : 0 };
 
-					if (beforeMinDate || afterMinDate) {
-						className = 'text-muted';
-						clickHandler = null;
-						style.cursor = 'default';
-					} else if (Date.parse(date) === Date.parse(selectedDate)) {
-						className = 'bg-primary';
-					} else if (Date.parse(date) === Date.parse(currentDate)) {
-						className = 'text-primary';
-					}
+          if (beforeMinDate || afterMinDate) {
+            className = 'text-muted';
+            clickHandler = null;
+            style.cursor = 'default';
+          } else if (Date.parse(date) === Date.parse(selectedDate)) {
+            className = 'bg-primary';
+          } else if (Date.parse(date) === Date.parse(currentDate)) {
+            className = 'text-primary';
+          }
 
-					week.push(<td
-						key={j}
-						data-day={day}
-						onClick={clickHandler}
-						style={style}
-						className={className}
-					>
-						{day}
-					</td>);
+          week.push(<td
+            key={j}
+            data-day={day}
+            onClick={clickHandler}
+            style={style}
+            className={className}
+          >
+            {day}
+          </td>);
           day++;
         } else {
           week.push(<td key={j} />);

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -94,11 +94,12 @@ const Calendar = createReactClass({
     showWeeks: React.PropTypes.bool
   },
 
-  handleClick(day) {
-    const newSelectedDate = this.setTimeToNoon(new Date(this.props.displayDate));
-    newSelectedDate.setDate(day);
-    this.props.onChange(newSelectedDate);
-  },
+	handleClick(e) {
+		const day = e.currentTarget.getAttribute('data-day');
+		const newSelectedDate = this.setTimeToNoon(new Date(this.props.displayDate));
+		newSelectedDate.setDate(day);
+		this.props.onChange(newSelectedDate);
+	},
 
   handleClickToday() {
     const newSelectedDate = this.setTimeToNoon(new Date());
@@ -157,27 +158,28 @@ const Calendar = createReactClass({
           const date = new Date(year, month, day, 12, 0, 0, 0).toISOString();
           const beforeMinDate = minDate && Date.parse(date) < Date.parse(minDate);
           const afterMinDate = maxDate && Date.parse(date) > Date.parse(maxDate);
-          if (beforeMinDate || afterMinDate) {
-            week.push(<td
-              key={j}
-              style={{ padding: this.props.cellPadding }}
-              className="text-muted"
-            >
-              {day}
-            </td>);
-          } else if (Date.parse(date) === Date.parse(selectedDate)) {
-            className = 'bg-primary';
-          } else if (Date.parse(date) === Date.parse(currentDate)) {
-            className = 'text-primary';
-          }
-          week.push(<td
-            key={j}
-            onClick={this.handleClick.bind(this, day)}
-            style={{ cursor: 'pointer', padding: this.props.cellPadding, borderRadius: this.props.roundedCorners ? 5 : 0 }}
-            className={className}
-          >
-            {day}
-          </td>);
+					let clickHandler = this.handleClick;
+					const style = { cursor: 'pointer', padding: this.props.cellPadding, borderRadius: this.props.roundedCorners ? 5 : 0 };
+
+					if (beforeMinDate || afterMinDate) {
+						className = 'text-muted';
+						clickHandler = null;
+						style.cursor = 'default';
+					} else if (Date.parse(date) === Date.parse(selectedDate)) {
+						className = 'bg-primary';
+					} else if (Date.parse(date) === Date.parse(currentDate)) {
+						className = 'text-primary';
+					}
+
+					week.push(<td
+						key={j}
+						data-day={day}
+						onClick={clickHandler}
+						style={style}
+						className={className}
+					>
+						{day}
+					</td>);
           day++;
         } else {
           week.push(<td key={j} />);


### PR DESCRIPTION
## Motivation and Context
If `minDate` or `maxDate` are set, several duplicate key warnings are raised. This commit fix that.
Moreover, the `handleClick` function binding has been moved out from the render method for [potentially performance reasons](https://facebook.github.io/react/docs/handling-events.html):

> We generally recommend binding in the constructor or using the property initializer syntax, to avoid this sort of performance problem.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
