### PR TITLE
Fix "Cannot read property 'slice' of undefined" bug with min/max dates

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -397,8 +397,8 @@ exports.default = (0, _createReactClass2.default)({
   makeDateValues: function makeDateValues(isoString) {
     var displayDate = void 0;
     var selectedDate = isoString ? new Date(isoString.slice(0, 10) + 'T12:00:00.000Z') : null;
-    var minDate = this.props.minDate ? new Date(isoString.slice(0, 10) + 'T12:00:00.000Z') : null;
-    var maxDate = this.props.maxDate ? new Date(isoString.slice(0, 10) + 'T12:00:00.000Z') : null;
+    var minDate = this.props.minDate ? new Date(this.props.minDate.slice(0, 10) + 'T12:00:00.000Z') : null;
+    var maxDate = this.props.maxDate ? new Date(this.props.maxDate.slice(0, 10) + 'T12:00:00.000Z') : null;
 
     var inputValue = isoString ? this.makeInputValueString(selectedDate) : null;
     if (selectedDate) {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -363,8 +363,8 @@ export default createReactClass({
   makeDateValues(isoString) {
     let displayDate;
     const selectedDate = isoString ? new Date(`${isoString.slice(0,10)}T12:00:00.000Z`) : null;
-    const minDate = this.props.minDate ? new Date(`${isoString.slice(0,10)}T12:00:00.000Z`) : null;
-    const maxDate = this.props.maxDate ? new Date(`${isoString.slice(0,10)}T12:00:00.000Z`) : null;
+    const minDate = this.props.minDate ? new Date(`${this.props.minDate.slice(0,10)}T12:00:00.000Z`) : null;
+    const maxDate = this.props.maxDate ? new Date(`${this.props.maxDate.slice(0,10)}T12:00:00.000Z`) : null;
 
     const inputValue = isoString ? this.makeInputValueString(selectedDate) : null;
     if (selectedDate) {


### PR DESCRIPTION
## Description

This fixes a bug in `makeDateValues()` that occurs if you specified a min and/or max date, but have set the value of the control to `null` or an empty value. It was caused by some typos.

You can reproduce this issue by set minDate (and/or maxDate), clicking to change the date, and then deleting the value.

## Motivation and Context

This fixes a bug that causes a runtime error that prevents `makeDateValues()` from fully running. That has other implications, including the `onChange` handler not running.

In the browser console, you'll get the error message `Uncaught TypeError: Cannot read property 'slice' of undefined`, as reported in issue #134

## How Has This Been Tested?

Only manually.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
