### PR TITLE
Move create-react-class from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "react": ">=0.14.0",
     "react-bootstrap": "^0.31.0"
   },
+  "dependencies": {
+    "create-react-class": "^15.5.2"
+  },
   "devDependencies": {
     "assert": "^1.4.1",
     "babel": "^6.23.0",
@@ -31,7 +34,6 @@
     "babel-preset-react": "^6.23.0",
     "babel-preset-stage-1": "^6.22.0",
     "co": "^4.6.0",
-    "create-react-class": "^15.5.2",
     "doctoc": "^1.3.0",
     "envify": "^4.0.0",
     "es6-promise": "^4.1.0",


### PR DESCRIPTION
`create-react-class` is required at runtime so it must exist in "dependencies" or it won't be installed in production.