### PR TITLE
Add option to disable calendar popover

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ DatePicker component. Renders as a [React-Bootstrap InputGroup](https://react-bo
     * **Optional**
     * **Type:** `bool`
     * **Example:** `false`
+  * `calendarDisabled` - Whether or not the calendar popover will be disabled.
+    * **Optional**
+    * **Type:** `bool`
+    * **Example:** `false`
   * `onChange` - Focus callback function.
     * **Optional**
     * **Type:** `function`

--- a/example/app.jsx
+++ b/example/app.jsx
@@ -129,6 +129,13 @@ const App = createReactClass({
             <HelpBlock>Help</HelpBlock>
           </FormGroup>
         </Col>
+        <Col sm={6}>
+          <FormGroup controlId="calendar_disabled">
+            <ControlLabel>Calendar Disabled</ControlLabel>
+            <DatePicker calendarDisabled={true} onChange={this.handleChange} placeholder="Placeholder" value={this.state.date} id="calendar_disabled_example" />
+            <HelpBlock>Help</HelpBlock>
+          </FormGroup>
+        </Col>
       </Row>
       <Row>
         <Col xs={6}>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -267,6 +267,7 @@ export default createReactClass({
     onFocus: PropTypes.func,
     autoFocus: PropTypes.bool,
     disabled: PropTypes.bool,
+    calendarDisabled: PropTypes.bool,
     weekStartsOnMonday: (props, propName, componentName) => {
       if (props[propName]) {
         return new Error(`Prop '${propName}' supplied to '${componentName}' is obsolete. Use 'weekStartsOn' instead.`);
@@ -328,6 +329,7 @@ export default createReactClass({
       showClearButton: true,
       autoFocus: false,
       disabled: false,
+      calendarDisabled: false,
       showTodayButton: false,
       todayButtonLabel: 'Today',
       autoComplete: 'on',
@@ -676,13 +678,8 @@ export default createReactClass({
           noValidate={this.props.noValidate}
           />;
 
-    return <InputGroup
-      ref="inputGroup"
-      bsClass={this.props.showClearButton ? this.props.bsClass : ''}
-      bsSize={this.props.bsSize}
-      id={this.props.id ? `${this.props.id}_group` : null}>
-      {control}
-      <Overlay
+    const overlay = !this.props.calendarDisabled
+      && <Overlay
         rootClose={true}
         onHide={this.handleHide}
         show={this.state.focused}
@@ -704,10 +701,18 @@ export default createReactClass({
             maxDate={this.props.maxDate}
             roundedCorners={this.props.roundedCorners}
             showWeeks={this.props.showWeeks}
-           />
+          />
         </Popover>
-      </Overlay>
-      <div ref="overlayContainer" style={{position: 'relative'}} />
+      </Overlay>;
+
+    return <InputGroup
+      ref="inputGroup"
+      bsClass={this.props.showClearButton ? this.props.bsClass : ''}
+      bsSize={this.props.bsSize}
+      id={this.props.id ? `${this.props.id}_group` : null}>
+      {control}
+      {overlay}
+      {!this.props.calendarDisabled && <div ref="overlayContainer" style={{position: 'relative'}} />}
       <input ref="hiddenInput" type="hidden" id={this.props.id} name={this.props.name} value={this.state.value || ''} data-formattedvalue={this.state.value ? this.state.inputValue : ''} />
       {this.props.showClearButton && !this.props.customControl && <InputGroup.Addon
         onClick={this.props.disabled ? null : this.clear}

--- a/test/core.test.jsx
+++ b/test/core.test.jsx
@@ -623,6 +623,24 @@ describe("Date Picker", function() {
     assertIsoStringsHaveSameDate(value, originalValue);
     ReactDOM.unmountComponentAtNode(container);
   }));
+  it("should disable the calendar.", co.wrap(function *(){
+    const id = UUID.v4();
+    const App = createReactClass({
+      render: function(){
+        return <div>
+          <DatePicker id={id} calendarDisabled={true} />
+        </div>;
+      }
+    });
+    yield new Promise(function(resolve, reject){
+      ReactDOM.render(<App />, container, resolve);
+    });
+    const inputElement = document.querySelector("input.form-control");
+    TestUtils.Simulate.focus(inputElement);
+    const popover = document.querySelector(".date-picker-popover");
+    assert.equal(popover, null);
+    ReactDOM.unmountComponentAtNode(container);
+  }));
   it("should display the correct day of the week in the calendar.", co.wrap(function *(){
     const id = UUID.v4();
     let value = null;


### PR DESCRIPTION
<!-- START doctoc generated TOC please keep comment here to allow auto update -->
<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
<h1>Table of Contents</h1>

- [Description](#description)
- [Motivation and Context](#motivation-and-context)
- [How Has This Been Tested?](#how-has-this-been-tested)
- [Types of changes](#types-of-changes)
- [Checklist:](#checklist)

<!-- END doctoc generated TOC please keep comment here to allow auto update -->

<!--- Thank you for your pull request! This is a community supported 
project initially released by https://github.com/wehriam for your use
and enjoyment. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
I added a prop called `calendarDisabled` which prevents a calendar popover from being rendered when the input is focused. I added a corresponding test as well as an example to the example page.

## Motivation and Context
This would be useful in cases where the user is entering a date far in the past, such as a birthday, and it's more straightforward to type the date than to click back month by month for possibly dozens of years.

## How Has This Been Tested?
I wrote a test which verifies that the popover isn't rendered when the `calendarDisabled` prop is `true`. I tested the component in Chrome 61.0.3163.100 on the examples page.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
