### PR TITLE
pass handleHide function to customComponent

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -656,6 +656,7 @@ export default createReactClass({
         autoComplete: this.props.autoComplete,
         onInvalid: this.props.onInvalid,
         noValidate: this.props.noValidate,
+        handleHide: this.handleHide,
       })
       : <FormControl
           onKeyDown={this.handleKeyDown}


### PR DESCRIPTION
Pass handleHide function to a custom input component so that the component can close the calendar when necessary